### PR TITLE
fix: when proxying to Neon Auth we now set

### DIFF
--- a/apps/dashboard/src/lib/server/auth.ts
+++ b/apps/dashboard/src/lib/server/auth.ts
@@ -94,6 +94,7 @@ export async function proxyAuthRequest(
   const ourOrigin = ourUrl.origin;
   const headers = new Headers(request.headers);
   headers.delete("host");
+  headers.set("Host", targetUrl.host);
   const incomingCookie = decodeLocalhostCookieHeader(headers.get("cookie") ?? "", ourHost);
   if (incomingCookie) headers.set("cookie", incomingCookie);
   const hasBody = request.method !== "GET" && request.method !== "HEAD";


### PR DESCRIPTION
Host:

## What changed
<!-- Brief description of changes -->

## Why
<!-- Reason for the change -->

## Canonical docs updated
<!-- List root or docs/ docs you updated (STATUS, ROADMAP, CHANGELOG, etc.) -->
- [ ] N/A
- [ ] Updated: ___

## Security impact
- [ ] None
- [ ] Low (docs/process only)
- [ ] Higher (describe below)

## Reliability impact
- [ ] None
- [ ] Describe if relevant

## Checks run
- [ ] `scripts/check-repo-hygiene.sh`
- [ ] `scripts/review-docs.sh`
- [ ] `scripts/check-secrets.sh`
- [ ] `scripts/check-dependency-policy.sh`
- [ ] Other (lint/typecheck if applicable): ___

## Scope confirmation
- [ ] This PR respects Phase 00 bootstrap constraints (no product/business logic unless gate lifted)
