### PR TITLE
Look, feel, harmony and detail: unified brand and shell

### DIFF
--- a/apps/dashboard/src/app.css
+++ b/apps/dashboard/src/app.css
@@ -19,6 +19,9 @@
   --rm-font-ui: var(--font-mono);
   --rm-radius: var(--radius-base);
   --rm-container-narrow: 56rem;
+  --rm-nav-height: 3.5rem;
+  --rm-section-padding: var(--space-12);
+  --rm-section-padding-sm: var(--space-8);
 }
 
 *,

--- a/apps/dashboard/src/lib/components/AppLogo.svelte
+++ b/apps/dashboard/src/lib/components/AppLogo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   /**
-   * Restormel app header lockup for dashboard sidebar and auth.
-   * Uses restormel-app-header-lockup.svg from static/.
+   * Restormel lockup for dashboard sidebar. Same asset as site nav (restormel-lockup-nav.svg)
+   * for one brand across site, docs, and dashboard. Height 28px matches marketing nav.
    */
   import { base } from '$app/paths';
 
@@ -13,7 +13,7 @@
 
 <a {href} class="app-logo {className}" aria-label="Restormel dashboard home">
   <img
-    src="{base}/restormel-app-header-lockup.svg"
+    src="{base}/restormel-lockup-nav.svg"
     alt="Restormel"
     width={compact ? 120 : 160}
     height={compact ? 18 : 24}

--- a/apps/dashboard/src/lib/components/EmptyState.svelte
+++ b/apps/dashboard/src/lib/components/EmptyState.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  /**
+   * Shared empty-state block: title, description, and one primary recovery action.
+   * Use for no projects, no keys, billing not set up, etc. (docs/ux-contracts.md)
+   */
+  import type { Snippet } from 'svelte';
+
+  export let title: string;
+  export let description: string;
+  export let children: Snippet;
+</script>
+
+<div class="empty-state">
+  <h2 class="empty-state-title">{title}</h2>
+  <p class="empty-state-desc">{description}</p>
+  <div class="empty-state-action">
+    {@render children()}
+  </div>
+</div>
+
+<style>
+  .empty-state {
+    background: var(--rm-surface-raised);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--rm-radius);
+    padding: var(--space-6);
+    margin: 0 0 var(--space-4);
+  }
+  .empty-state-title {
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--rm-text);
+    margin: 0 0 var(--space-2);
+  }
+  .empty-state-desc {
+    color: var(--rm-muted);
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-4);
+  }
+  .empty-state-action {
+    margin: 0;
+  }
+</style>

--- a/apps/dashboard/src/routes/+layout.svelte
+++ b/apps/dashboard/src/routes/+layout.svelte
@@ -15,7 +15,7 @@
   <div class="shell">
     <aside class="sidebar">
       <div class="logo">
-        <AppLogo height="26" />
+        <AppLogo height="28" />
       </div>
       <nav class="nav" aria-label="Dashboard">
         <a href={base + "/"} class="nav-link">Overview</a>

--- a/apps/dashboard/src/routes/+page.svelte
+++ b/apps/dashboard/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { base } from "$app/paths";
+  import EmptyState from "$lib/components/EmptyState.svelte";
 
   export let data: { projects: { id: string; name: string }[]; projectsError?: string | null };
 </script>
@@ -11,7 +12,12 @@
   <p class="error-msg" role="alert">{data.projectsError}. Check Vercel logs for database errors.</p>
 {/if}
 {#if data.projects.length === 0}
-  <p class="empty">No projects yet. <a href={base + "/projects"}>Create one</a>.</p>
+  <EmptyState
+    title="No projects yet"
+    description="Create a project to get API keys and use the Cloud API."
+  >
+    <a href={base + "/projects"} class="btn btn-primary">Create a project</a>
+  </EmptyState>
 {:else}
   <ul class="project-list">
     {#each data.projects as p}
@@ -26,35 +32,35 @@
 <style>
   .page-title {
     font-family: var(--rm-font-display);
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     font-weight: 600;
     color: var(--rm-text);
-    margin: 0 0 0.5rem;
+    margin: 0 0 var(--space-2);
   }
   .page-desc {
     color: var(--rm-muted);
-    font-size: 0.875rem;
-    margin: 0 0 1rem;
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-4);
   }
   .error-msg {
-    color: var(--rm-error, #c95c5c);
-    font-size: 0.875rem;
-    margin: 0 0 1rem;
+    color: var(--coral-alert);
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-4);
   }
   .empty {
     color: var(--rm-muted);
-    margin: 0 0 1rem;
+    margin: 0 0 var(--space-4);
   }
   .project-list {
     list-style: none;
     padding: 0;
-    margin: 0 0 1rem;
+    margin: 0 0 var(--space-4);
   }
   .project-list li {
-    padding: 0.5rem 0;
+    padding: var(--space-2) 0;
     border-bottom: 1px solid var(--rm-border);
   }
   .btn-link {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
   }
 </style>

--- a/apps/dashboard/src/routes/projects/+page.svelte
+++ b/apps/dashboard/src/routes/projects/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { base } from "$app/paths";
   import { invalidateAll } from "$app/navigation";
+  import EmptyState from "$lib/components/EmptyState.svelte";
 
   export let data: { projects: { id: string; name: string; createdAt: number }[]; projectsError?: string | null };
 
@@ -45,59 +46,68 @@
 {#if createError}
   <p class="error-msg" role="alert">{createError}</p>
 {/if}
-<div class="create-form">
+<div class="create-form" id="create-form">
   <input type="text" bind:value={newName} placeholder="Project name" class="input" />
   <button class="btn btn-primary" onclick={createProject} disabled={creating || !newName.trim()}>
     {creating ? "Creating…" : "Create project"}
   </button>
 </div>
 
-<ul class="project-list">
-  {#each data.projects as p}
-    <li>
-      <a href={base + "/projects/" + p.id}>{p.name}</a>
-    </li>
-  {/each}
-</ul>
+{#if data.projects.length === 0}
+  <EmptyState
+    title="No projects yet"
+    description="Create your first project to get API keys and use the Cloud API."
+  >
+    <a href="#create-form" class="btn btn-primary">Create a project</a>
+  </EmptyState>
+{:else}
+  <ul class="project-list">
+    {#each data.projects as p}
+      <li>
+        <a href={base + "/projects/" + p.id}>{p.name}</a>
+      </li>
+    {/each}
+  </ul>
+{/if}
 
 <style>
   .page-title {
     font-family: var(--rm-font-display);
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     font-weight: 600;
     color: var(--rm-text);
-    margin: 0 0 0.5rem;
+    margin: 0 0 var(--space-2);
   }
   .page-desc {
     color: var(--rm-muted);
-    font-size: 0.875rem;
-    margin: 0 0 1rem;
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-4);
   }
   .error-msg {
-    color: var(--rm-error, #c95c5c);
-    font-size: 0.875rem;
-    margin: 0 0 1rem;
+    color: var(--coral-alert);
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-4);
   }
   .create-form {
     display: flex;
-    gap: 0.75rem;
-    margin-bottom: 1.5rem;
+    gap: var(--space-3);
+    margin-bottom: var(--space-6);
     flex-wrap: wrap;
   }
   .input {
-    padding: 0.5rem 0.75rem;
+    padding: var(--space-2) var(--space-3);
     border: 1px solid var(--rm-border);
     border-radius: var(--rm-radius);
     background: var(--rm-surface);
     color: var(--rm-text);
     font-family: inherit;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     min-width: 12rem;
   }
   .btn {
-    padding: 0.5rem 1rem;
+    padding: var(--space-2) var(--space-4);
     border-radius: var(--rm-radius);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     font-weight: 500;
     border: none;
     cursor: pointer;
@@ -116,7 +126,7 @@
     margin: 0;
   }
   .project-list li {
-    padding: 0.5rem 0;
+    padding: var(--space-2) 0;
     border-bottom: 1px solid var(--rm-border);
   }
 </style>

--- a/apps/dashboard/src/routes/projects/[id]/+page.svelte
+++ b/apps/dashboard/src/routes/projects/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { base } from "$app/paths";
   import { invalidateAll } from "$app/navigation";
+  import EmptyState from "$lib/components/EmptyState.svelte";
 
   export let data: {
     project: { id: string; name: string } | null;
@@ -66,19 +67,30 @@
       </div>
     {/if}
 
-    <button class="btn btn-primary" onclick={generateKey} disabled={generating}>
-      {generating ? "Generating…" : "Generate API key"}
-    </button>
+    {#if data.keys.length === 0 && !newKeyRaw}
+      <EmptyState
+        title="No API keys yet"
+        description="Generate an API key to use the Cloud API. Copy it when created; we won’t show it again."
+      >
+        <button class="btn btn-primary" onclick={generateKey} disabled={generating}>
+          {generating ? "Generating…" : "Generate API key"}
+        </button>
+      </EmptyState>
+    {:else}
+      <button class="btn btn-primary" onclick={generateKey} disabled={generating}>
+        {generating ? "Generating…" : "Generate API key"}
+      </button>
 
-    {#if data.keys.length > 0}
-      <ul class="key-list">
-        {#each data.keys as k}
-          <li class="key-row">
-            <code class="key-prefix">{k.keyPrefix}</code>
-            <button type="button" class="btn btn-danger" onclick={() => revokeKey(k.id)}>Revoke</button>
-          </li>
-        {/each}
-      </ul>
+      {#if data.keys.length > 0}
+        <ul class="key-list">
+          {#each data.keys as k}
+            <li class="key-row">
+              <code class="key-prefix">{k.keyPrefix}</code>
+              <button type="button" class="btn btn-danger" onclick={() => revokeKey(k.id)}>Revoke</button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
     {/if}
   </section>
 
@@ -88,52 +100,52 @@
 <style>
   .page-title {
     font-family: var(--rm-font-display);
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     font-weight: 600;
     color: var(--rm-text);
-    margin: 0 0 0.5rem;
+    margin: 0 0 var(--space-2);
   }
   .page-desc {
     color: var(--rm-muted);
-    font-size: 0.875rem;
-    margin: 0 0 1rem;
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-4);
   }
   .section {
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--space-6);
   }
   .section-title {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 600;
     color: var(--rm-text);
-    margin: 0 0 0.25rem;
+    margin: 0 0 var(--space-1);
   }
   .section-desc {
     color: var(--rm-muted);
-    font-size: 0.8125rem;
-    margin: 0 0 0.75rem;
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-3);
   }
   .new-key-box {
     background: var(--rm-surface-raised);
     border: 1px solid var(--rm-border);
     border-radius: var(--rm-radius);
-    padding: 1rem;
-    margin-bottom: 0.75rem;
+    padding: var(--space-4);
+    margin-bottom: var(--space-3);
   }
   .new-key-label {
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     color: var(--rm-dim);
-    margin: 0 0 0.25rem;
+    margin: 0 0 var(--space-1);
   }
   .new-key-value {
-    font-size: 0.8125rem;
+    font-size: var(--text-sm);
     word-break: break-all;
     display: block;
-    margin-bottom: 0.5rem;
+    margin-bottom: var(--space-2);
   }
   .btn {
-    padding: 0.5rem 1rem;
+    padding: var(--space-2) var(--space-4);
     border-radius: var(--rm-radius);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     font-weight: 500;
     border: none;
     cursor: pointer;
@@ -153,26 +165,27 @@
     border: 1px solid var(--rm-border);
   }
   .btn-danger:hover {
-    color: #c95c5c;
-    border-color: #c95c5c;
+    color: var(--coral-alert);
+    border-color: var(--coral-alert);
   }
   .key-list {
     list-style: none;
     padding: 0;
-    margin: 1rem 0 0;
+    margin: var(--space-4) 0 0;
   }
   .key-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.5rem 0;
+    padding: var(--space-2) 0;
     border-bottom: 1px solid var(--rm-border);
   }
   .key-prefix {
-    font-size: 0.8125rem;
+    font-size: var(--text-sm);
     color: var(--rm-muted);
   }
   .error {
-    color: #c95c5c;
+    color: var(--coral-alert);
+    font-size: var(--text-sm);
   }
 </style>

--- a/apps/dashboard/src/routes/projects/[id]/usage/+page.svelte
+++ b/apps/dashboard/src/routes/projects/[id]/usage/+page.svelte
@@ -18,21 +18,22 @@
 <style>
   .page-title {
     font-family: var(--rm-font-display);
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     font-weight: 600;
     color: var(--rm-text);
-    margin: 0 0 0.5rem;
+    margin: 0 0 var(--space-2);
   }
   .page-desc {
     color: var(--rm-muted);
-    font-size: 0.875rem;
-    margin: 0 0 1rem;
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-4);
   }
   .placeholder {
     color: var(--rm-dim);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
   }
   .error {
-    color: #c95c5c;
+    color: var(--coral-alert);
+    font-size: var(--text-sm);
   }
 </style>

--- a/apps/dashboard/src/routes/settings/+page.svelte
+++ b/apps/dashboard/src/routes/settings/+page.svelte
@@ -21,30 +21,30 @@
 <style>
   .page-title {
     font-family: var(--rm-font-display);
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     font-weight: 600;
     color: var(--rm-text);
-    margin: 0 0 0.5rem;
+    margin: 0 0 var(--space-2);
   }
   .page-desc {
     color: var(--rm-muted);
-    font-size: 0.875rem;
-    margin: 0 0 1rem;
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-4);
   }
   .settings-list {
     margin: 0;
   }
   .settings-list dt {
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     color: var(--rm-dim);
-    margin-top: 0.75rem;
+    margin-top: var(--space-3);
   }
   .settings-list dd {
-    margin: 0.25rem 0 0;
-    font-size: 0.875rem;
+    margin: var(--space-1) 0 0;
+    font-size: var(--text-sm);
   }
   .settings-list dd code {
-    font-size: 0.8125rem;
+    font-size: var(--text-sm);
     color: var(--rm-muted);
   }
 </style>

--- a/apps/dashboard/static/restormel-lockup-nav.svg
+++ b/apps/dashboard/static/restormel-lockup-nav.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="96" viewBox="0 0 640 96" fill="none">
+
+
+    <rect width="640" height="96" rx="16" fill="#070B12"/>
+    <g transform="translate(24,20)">
+      <rect x="0" y="0" width="56" height="56" rx="0" stroke="#C9F7D5" stroke-width="1.5"/>
+<rect x="8" y="8" width="40" height="40" rx="0" stroke="#C9F7D5" stroke-width="1.5"/>
+<rect x="16" y="16" width="24" height="24" rx="0" stroke="#C9F7D5" stroke-width="1.5"/>
+<rect x="24" y="24" width="8" height="8" rx="0" stroke="#C9F7D5" stroke-width="1.5"/>
+    </g>
+    <text x="104" y="58" fill="#E8EDF3" font-size="34" font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-weight="600">Restormel</text>
+    
+</svg>

--- a/apps/site/src/content/docs/keys/docs/cloud-api.md
+++ b/apps/site/src/content/docs/keys/docs/cloud-api.md
@@ -24,3 +24,10 @@ See the portal’s [How it all fits together](https://restormel-keys-gateway-mai
 - [Developer Portal (API reference + Try it)](https://restormel-keys-gateway-main-bc13eba.zuplo.site)
 - [Introduction & authentication](https://restormel-keys-gateway-main-bc13eba.zuplo.site/introduction)
 - [Dashboard](https://restormel.dev/keys/dashboard)
+
+## See also
+
+- [Dashboard](/keys/dashboard/) — create projects and API keys
+- [Sign in](/keys/dashboard/login) — authenticate with GitHub
+- [Docs](/keys/docs/) — framework compatibility and guides
+- [Pricing](/keys/pricing/) — tiers and plans

--- a/apps/site/src/content/docs/keys/docs/compatibility.md
+++ b/apps/site/src/content/docs/keys/docs/compatibility.md
@@ -68,3 +68,10 @@ If you’re on Next.js App Router, the fastest path is:
 3. Use the core on the server for resolution and cost; use the React components on the client for UI.
 
 A full App Router example is available in the repo (`apps/demo-next`). A dedicated Next.js guide will be linked here when added.
+
+## See also
+
+- [Cloud API](/keys/docs/cloud-api/) — gateway URL, Developer Portal, and API reference
+- [Dashboard](/keys/dashboard/) — create projects and API keys
+- [Sign in](/keys/dashboard/login) — authenticate with GitHub
+- [Pricing](/keys/pricing/) — tiers and plans

--- a/apps/site/src/layouts/MarketingLayout.astro
+++ b/apps/site/src/layouts/MarketingLayout.astro
@@ -115,6 +115,7 @@ import LogoLockup from "../components/LogoLockup.astro";
   .nav {
     border-bottom: 1px solid var(--rm-border);
     background: var(--rm-surface);
+    min-height: var(--rm-nav-height);
   }
 
   .nav-inner {
@@ -125,10 +126,12 @@ import LogoLockup from "../components/LogoLockup.astro";
     align-items: center;
     justify-content: space-between;
     gap: var(--space-6);
+    min-height: var(--rm-nav-height);
   }
 
   .logo {
     display: inline-flex;
+    align-items: center;
     text-decoration: none;
     transition: opacity var(--duration-fast) var(--ease);
   }

--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -27,6 +27,7 @@
   --rm-reading-width: 65ch;
   --rm-card-radius: var(--radius-md);
   --rm-card-shadow: var(--shadow-base);
+  --rm-nav-height: 3.5rem;
 }
 
 @media (max-width: 640px) {

--- a/apps/site/src/styles/starlight-theme.css
+++ b/apps/site/src/styles/starlight-theme.css
@@ -55,11 +55,11 @@
   --sl-line-height: var(--leading-relaxed);
   --sl-line-height-headings: var(--leading-tight);
 
-  /* Layout alignment with marketing site */
+  /* Layout alignment with marketing site (--rm-nav-height from global.css) */
   --sl-content-width: 52rem;
   --sl-content-pad-x: var(--space-6);
   --sl-content-gap-y: var(--space-8);
-  --sl-nav-height: 3.5rem;
+  --sl-nav-height: var(--rm-nav-height, 3.5rem);
   --sl-sidebar-width: 20rem;
   --sl-sidebar-pad-x: var(--space-5);
   --sl-nav-pad-x: var(--space-6);

--- a/docs/design-system-index.md
+++ b/docs/design-system-index.md
@@ -18,15 +18,17 @@ One login, one cookie, same links everywhere. Sign-in uses a single entry point 
 
 Logo and lockup are **core layout primitives**, not decoration. Use them consistently so brand is embedded in structure.
 
+**One lockup in nav contexts:** The same asset (**restormel-lockup-nav.svg**) is used for nav/header/sidebar across site, docs, and dashboard. No alternate lockup in these contexts so the product reads as one brand. Site and Starlight use it via [LogoLockup.astro](../apps/site/src/components/LogoLockup.astro) and astro.config.mjs `logo.src`; dashboard uses it in [AppLogo.svelte](../apps/dashboard/src/lib/components/AppLogo.svelte) (copied to dashboard static). Hero and marketing full-width contexts may use the larger lockup variants (dark/light); nav, header, and sidebar must use the nav lockup only.
+
 | Context | Asset | Size / rule | Where |
 |--------|--------|-------------|--------|
-| Marketing nav (header) | Lockup | Height 28px; clear-space = nav padding rhythm | [LogoLockup.astro](../apps/site/src/components/LogoLockup.astro) variant `nav`, `height="28"`. |
-| Marketing footer | Lockup | Height 24px | LogoLockup variant `nav`, `height="24"`. |
-| Dashboard sidebar | App lockup | Height 26–28px; horizontal padding matches nav links | [AppLogo.svelte](../apps/dashboard/src/lib/components/AppLogo.svelte); `height="26"` or `"28px"`. |
-| Docs (Starlight) | Starlight logo config | Same lockup as marketing nav; sizing via Starlight header | astro.config.mjs `logo.src`; theme uses `--sl-*` aligned to `--rm-*`. |
+| Marketing nav (header) | restormel-lockup-nav.svg | Height 28px; min-height container `--rm-nav-height` (3.5rem) | [LogoLockup.astro](../apps/site/src/components/LogoLockup.astro) variant `nav`, `height="28"`; [MarketingLayout.astro](../apps/site/src/layouts/MarketingLayout.astro) `.nav` / `.nav-inner`. |
+| Marketing footer | restormel-lockup-nav.svg | Height 24px | LogoLockup variant `nav`, `height="24"`. |
+| Dashboard sidebar | restormel-lockup-nav.svg | Height 28px; padding `var(--space-4)` to match nav links | [AppLogo.svelte](../apps/dashboard/src/lib/components/AppLogo.svelte) `height="28"`; layout `.logo` padding. |
+| Docs (Starlight) | restormel-lockup-nav.svg | Same as marketing nav; header min-height `--sl-nav-height` (3.5rem) | astro.config.mjs `logo.src`; [starlight-theme.css](../apps/site/src/styles/starlight-theme.css) `.header` / `.sl-navbar`. |
 | Icon-only (favicon, tight spaces) | Mark | 24–32px; use [LogoMark.astro](../apps/site/src/components/LogoMark.astro) or equivalent. | Favicon, OG, or icon-only UI. |
 
-**Rules:** (1) Lockup = mark + wordmark; use in nav, header, footer. (2) Mark only = concentric symbol; use when space is tight or icon-only is required. (3) Sizing: nav/header = 28px height; footer = 24px; dashboard sidebar = 26–28px. (4) Clear-space: same vertical/horizontal rhythm as surrounding nav (e.g. `--space-4` / `--space-6`). (5) Focus and contrast: use `--focus-ring-*` and ensure logo has sufficient contrast on `--rm-surface` / `--rm-bg`. (6) All shell headers/sidebars that show the logo must use the same tokenized spacing and typography hierarchy so the logo sits in the layout system, not as a tag-on.
+**Rules:** (1) **One lockup in nav/header/sidebar:** restormel-lockup-nav.svg everywhere; no exceptions. (2) Lockup = mark + wordmark; use in nav, header, footer. (3) Mark only = concentric symbol; use when space is tight or icon-only is required. (4) **Sizing mandatory:** nav/header = 28px height; footer = 24px; dashboard sidebar = 28px. (5) **Clear-space:** same vertical/horizontal rhythm as surrounding nav (`--space-4` / `--space-6`); header/sidebar use `--rm-nav-height` or equivalent so the logo sits in the layout grid. (6) Focus and contrast: use `--focus-ring-*`; sufficient contrast on `--rm-surface` / `--rm-bg`. (7) All shell headers/sidebars use the same tokenized spacing so the logo is part of the layout system, not a tag-on.
 
 ## Canonical documents
 
@@ -64,3 +66,22 @@ Logo and lockup are **core layout primitives**, not decoration. Use them consist
 5. **Semantic color meaning** — Blue = primary/selection, Teal = verified/success, Amber = warning, Coral = error, Violet = inference/reasoning.
 
 When adding or changing UI, prefer tokens and components from this system; avoid one-off colors or typography.
+
+## Visual harmony checklist
+
+Use this checklist for reviews and drift checks so the product keeps one look and feel across site, docs, and dashboard.
+
+1. **Logo asset and sizing (nav/header/sidebar)**  
+   One lockup (restormel-lockup-nav.svg) in all shells; nav/header/sidebar height 28px; footer 24px; container min-height `--rm-nav-height` (3.5rem); same horizontal padding (`--space-4` / `--space-6`) so the logo sits in the layout grid.
+
+2. **Nav labels and canonical URLs**  
+   Only: Keys, Docs, Pricing, GitHub, Dashboard (and Sign in in docs Product section). Same URLs everywhere: Dashboard → `/keys/dashboard`, Sign in → `/keys/dashboard/login`, Docs → `/keys/docs/`, Pricing → `/keys/pricing`, Keys → `/keys`. No alternate labels or paths unless explicitly added.
+
+3. **Section pattern (title + intro + content)**  
+   Marketing/docs: section-title (h2) + optional section-intro (p) + content; spacing `--space-6` / `--space-8`. Dashboard: page-title (h1) + page-desc (p) + content; `.page-title` margin `0 0 var(--space-2)`, `.page-desc` margin `0 0 var(--space-4)`; font sizes `var(--text-2xl)` and `var(--text-sm)`; desc color `--rm-muted`.
+
+4. **Button and card tokens**  
+   Buttons and cards use `--rm-radius`, `--rm-sage`, `--rm-border`, `--rm-surface-raised` and padding scale `--space-2`, `--space-4`, `--space-6`. Same tokens on site and dashboard so components are visually interchangeable.
+
+5. **Empty and error state pattern**  
+   Every empty view: explicit copy + one primary recovery action (e.g. Create a project, Generate API key). Every error: clear message + recovery (Try again, Sign in, link to docs). Use shared `.empty-state` (title, description, CTA) and semantic error styling (`--coral-alert` / `--rk-*` error tokens). Loading states shown (e.g. “Creating…”, “Generating…”); no blank content during requests.

--- a/docs/ux-contracts.md
+++ b/docs/ux-contracts.md
@@ -70,10 +70,19 @@ Every user-facing flow must define and handle these states where applicable:
 
 **Destructive actions:** Require explicit user confirmation before execution (per [.cursor/rules/04-ux-safety.mdc](../.cursor/rules/04-ux-safety.mdc)).
 
-## 4. Application
+## 4. Section pattern (shell rhythm)
 
-- **Site (Astro):** MarketingLayout nav and footer use the navigation model and canonical URLs. Pricing and docs use the same links and copy conventions.
-- **Dashboard (SvelteKit):** Layout and routes use the same URLs; welcome and error blocks use state conventions and copy registry terms.
+One pattern for every major section so the product shares the same rhythm:
+
+- **Marketing and docs:** Section = **section-title** (h2) + optional **section-intro** (p) + content. Spacing: `--space-6` between title and intro, `--space-6` or `--space-8` below intro to content. Use `.section-title` and `.section-intro` (or equivalent) with tokenized margins and `--rm-muted` for intro text.
+- **Dashboard:** Page = **page-title** (h1) + **page-desc** (p) + content. Use `.page-title` and `.page-desc` with `margin: 0 0 var(--space-2)` and `margin: 0 0 var(--space-4)` respectively; font size `var(--text-2xl)` for title, `var(--text-sm)` for desc, color `--rm-muted` for desc. Sub-sections use the same pattern (e.g. `.section-title` + `.section-desc` + content) with tokenized spacing.
+
+Apply this pattern on all dashboard pages (Overview, Projects, Billing, Settings, project detail, usage) and keep site Keys/Pricing sections aligned. Buttons and cards use `--rm-radius`, `--rm-sage`, `--rm-border`, `--rm-surface-raised` and padding scale `--space-2`, `--space-4`, `--space-6` so they are visually interchangeable across site and dashboard.
+
+## 5. Application
+
+- **Site (Astro):** MarketingLayout nav and footer use the navigation model and canonical URLs. Section pattern: `.section-title` + `.section-intro` + content. Pricing and docs use the same links and copy conventions.
+- **Dashboard (SvelteKit):** Layout and routes use the same URLs; welcome and error blocks use state conventions and copy registry terms. Section pattern: `.page-title` + `.page-desc` (and `.section-title` + `.section-desc` for sub-sections) with tokenized spacing.
 - **Docs (Starlight):** Sidebar and content use Dashboard/Sign in links and product nouns from the registry.
 - **Embeddable components:** KeyManager and other embeddables use the same security/key copy and state patterns (loading/error/empty/success) where applicable.
 


### PR DESCRIPTION
## Summary

Implements the **Look, feel, harmony and detail** plan to unify look and feel across restormel.dev, /keys, docs, and dashboard so the site feels like one product.

## Changes

### 1. Logo and brand embedding
- **One lockup everywhere:** Dashboard now uses the same `restormel-lockup-nav.svg` as site and Starlight (copied to dashboard static); removed use of `restormel-app-header-lockup.svg`.
- **Anchor treatment:** `--rm-nav-height: 3.5rem` in global.css and dashboard app.css; MarketingLayout and Starlight header use same min-height and padding; dashboard sidebar logo uses 28px height and tokenized padding.
- **Docs:** design-system-index "Brand and logo usage" updated: one lockup for nav/header/sidebar, 28px nav / 24px footer, clear-space mandatory.

### 2. Shared shell rhythm and primitives
- **Tokens:** `--rm-nav-height`, `--rm-section-padding`, `--rm-section-padding-sm` in dashboard; site already had nav height in global.css.
- **Section pattern:** Documented in ux-contracts (section-title + section-intro + content; dashboard page-title + page-desc with tokenized spacing).
- **Dashboard pages:** Overview, Projects, Billing, Settings, project detail, usage use `var(--text-2xl)`, `var(--text-sm)`, `var(--space-2)`, `var(--space-4)`, `var(--coral-alert)` for titles, descriptions, and errors so rhythm matches across the app.

### 3. Detail: section intros, empty states, docs
- **EmptyState component:** New shared `EmptyState.svelte` (title, description, CTA slot) used for no projects (Overview + Projects) and no API keys (project detail).
- **Section intros:** All dashboard pages already had or now have page-desc; kept and aligned with tokens.
- **Docs:** "See also" added to cloud-api.md and compatibility.md with canonical links (Dashboard, Sign in, Docs, Pricing).
- **Error/loading:** Dashboard error and danger states use `var(--coral-alert)`; loading copy (Creating…, Generating…) already present; pricing `#checkout-message` unchanged.

### 4. Harmony checklist
- **design-system-index:** New "Visual harmony checklist" subsection: (1) logo asset and sizing, (2) nav labels and canonical URLs, (3) section pattern, (4) button/card tokens, (5) empty and error state pattern. One-time verification pass completed.

## Out of scope (per plan)
- Zuplo Developer Portal styling (hosted by Zuplo).
- Full redesign or new product features.

## Testing
- `scripts/review-docs.sh`, `check-secrets.sh`, `check-repo-hygiene.sh`, `check-dependency-policy.sh` run and passed.

Made with [Cursor](https://cursor.com)