### PR TITLE
Unify keys experience + 404 fix (favicon, root route)

### DIFF
--- a/apps/dashboard/src/routes/favicon.ico/+server.ts
+++ b/apps/dashboard/src/routes/favicon.ico/+server.ts
@@ -1,0 +1,7 @@
+import { redirect } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+/** Redirect browsers that request /favicon.ico to our SVG favicon. */
+export const GET: RequestHandler = () => {
+  throw redirect(302, "/favicon.svg");
+};

--- a/apps/dashboard/vercel.json
+++ b/apps/dashboard/vercel.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "cd .. && pnpm install",
-  "buildCommand": "pnpm run build",
-  "rewrites": [
-    { "source": "/", "destination": "/keys/dashboard" }
-  ]
+  "buildCommand": "pnpm run build"
 }


### PR DESCRIPTION
Unified SvelteKit app (dashboard at /keys/dashboard, site/docs on Vercel) and fix 404 on restormel.dev: favicon.ico redirect, remove root rewrite in apps/dashboard/vercel.json.

Made with [Cursor](https://cursor.com)