### PR TITLE
fix(dashboard-docs): unify walkthrough CodeBlock/callouts + quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,12 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Test
         run: pnpm --filter @restormel/keys test
+      - name: Dashboard check (svelte-check)
+        run: pnpm --filter dashboard run check
+      - name: Dashboard build
+        run: pnpm --filter dashboard run build
+      - name: Dashboard tests
+        run: pnpm --filter dashboard run test
 
   demo-next:
     runs-on: ubuntu-latest

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,7 +6,7 @@ Current state and next actions. Single source for "where we are"; keep aligned w
 
 **State:** Phase 00 bootstrap complete. **@restormel/keys v0.1.0** is published to npm; first publish and Phase 1 manual steps are done. Phase 2 complete (Svelte, elements, React, CLI, Next.js demo, SOPHIA runbook, a11y, publish, SvelteKit demo). Phase 3 started: Astro + Starlight marketing site (3.1) in `apps/site`; Keys experience unification (Phase A–D) done: dashboard logged-out UX and SSO, brand shell and logo, journey fixes, docs/Zuplo same-link and documentation strategy, shared tokens package (`@restormel/keys-tokens`), UX contracts, reintegration seams in ARCHITECTURE.md.
 
-**Next:** Phase 3.2 (Keys landing page), 3.3 (Pricing), 3.4 (dashboard), etc. per [docs/reference/09-prompt-pack-phase-3.md](docs/reference/09-prompt-pack-phase-3.md). For a practical remaining backlog (completed vs partial vs missing, tech debt, next tasks), see [docs/reference/remaining-backlog-after-implementation.md](docs/reference/remaining-backlog-after-implementation.md).
+**Next:** Phase 3.2 (Keys landing page), 3.3 (Pricing), 3.4 (dashboard), etc. per [docs/reference/09-prompt-pack-phase-3.md](docs/reference/09-prompt-pack-phase-3.md). For a practical remaining backlog (completed vs partial vs missing, tech debt, next tasks), see [docs/reference/remaining-backlog-after-implementation.md](docs/reference/remaining-backlog-after-implementation.md). **SOPHIA dogfooding** (ingestion pipeline + fallback routes/policies + UI embedding for model selection): [docs/reference/sophia-dogfooding-plan.md](docs/reference/sophia-dogfooding-plan.md).
 
 **Blockers:** None.
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -18,6 +18,8 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
+    "@restormel/keys": "workspace:*",
+    "@restormel/keys-react": "workspace:*",
     "@sveltejs/adapter-vercel": "^6.3.3",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",

--- a/apps/dashboard/src/hooks.server.ts
+++ b/apps/dashboard/src/hooks.server.ts
@@ -10,9 +10,6 @@ import { getBearerToken } from "$lib/server/bearer";
 import { verifyGatewayKey, verifyManagementKey } from "$lib/server/neon";
 
 export const handle: Handle = async ({ event, resolve }) => {
-  // #region agent log
-  fetch('http://127.0.0.1:7463/ingest/4d73a77a-e2c7-48aa-ae41-73a13b42405f',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4fc0f8'},body:JSON.stringify({sessionId:'4fc0f8',location:'hooks.server.ts:12',message:'request reached SvelteKit handle',data:{method:event.request.method,url:event.url.pathname,host:event.url.host},timestamp:Date.now(),hypothesisId:'C-D'})}).catch(()=>{});
-  // #endregion
   try {
     const { data: session } = await getSession(event.request, event.url.host);
     if (session?.user) {

--- a/apps/dashboard/src/lib/components/docs/CodeBlock.svelte
+++ b/apps/dashboard/src/lib/components/docs/CodeBlock.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+  type CodeTab = {
+    id?: string;
+    label: string;
+    language?: string;
+    code: string;
+  };
+
+  export let code: string | undefined = undefined;
+  export let language: string | undefined = undefined;
+  export let tabs: CodeTab[] | undefined = undefined;
+
+  let activeIdx = 0;
+  let copied = false;
+
+  $: hasTabs = Array.isArray(tabs) && tabs.length > 0;
+  $: active = hasTabs ? tabs![activeIdx] : null;
+  $: displayedCode = hasTabs ? active!.code : code ?? "";
+  $: displayedLanguage = hasTabs ? active!.language : language;
+
+  async function copy() {
+    const text = displayedCode;
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+      window.setTimeout(() => (copied = false), 1200);
+    } catch {
+      // Fallback: select & copy
+      const el = document.getElementById(codeId);
+      if (!el) return;
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      try {
+        document.execCommand("copy");
+        copied = true;
+        window.setTimeout(() => (copied = false), 1200);
+      } finally {
+        sel?.removeAllRanges();
+      }
+    }
+  }
+
+  const codeId = `code-${Math.random().toString(16).slice(2)}`;
+</script>
+
+<div class="codeblock" data-has-tabs={hasTabs} data-language={displayedLanguage ?? ""}>
+  <div class="codeblock-toolbar">
+    {#if hasTabs}
+      <div class="codeblock-tabs" role="tablist" aria-label="Code variants">
+        {#each tabs as tab, i (tab.id ?? tab.label)}
+          <button
+            type="button"
+            class="codeblock-tab"
+            role="tab"
+            aria-selected={i === activeIdx}
+            on:click={() => (activeIdx = i)}
+          >
+            {tab.label}
+          </button>
+        {/each}
+      </div>
+    {:else}
+      <div class="codeblock-label">
+        {#if displayedLanguage}
+          <span class="codeblock-lang">{displayedLanguage}</span>
+        {:else}
+          <span class="codeblock-lang">Code</span>
+        {/if}
+      </div>
+    {/if}
+
+    <button type="button" class="codeblock-copy" on:click={copy}>
+      {#if copied}
+        Copied
+      {:else}
+        Copy
+      {/if}
+    </button>
+  </div>
+
+  <pre class="codeblock-pre"><code id={codeId}>{displayedCode}</code></pre>
+</div>
+
+<style>
+  .codeblock {
+    background: color-mix(in oklab, var(--rm-surface) 85%, black 15%);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    margin: 0 0 var(--space-4);
+  }
+
+  .codeblock-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--rm-border);
+    background: color-mix(in oklab, var(--rm-surface-raised, var(--rm-surface)) 80%, black 20%);
+  }
+
+  .codeblock-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 2rem;
+  }
+
+  .codeblock-lang {
+    font-size: var(--text-xs);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--rm-muted);
+  }
+
+  .codeblock-tabs {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .codeblock-tab {
+    border: 1px solid var(--rm-border);
+    background: var(--rm-bg);
+    color: var(--rm-muted);
+    font-size: var(--text-xs);
+    padding: 0.35rem 0.6rem;
+    border-radius: var(--radius);
+    cursor: pointer;
+  }
+  .codeblock-tab[aria-selected="true"] {
+    color: var(--rm-fg, var(--rm-text, #fff));
+    border-color: color-mix(in oklab, var(--rm-primary) 60%, var(--rm-border));
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--rm-primary) 22%, transparent);
+  }
+
+  .codeblock-copy {
+    border: 1px solid var(--rm-border);
+    background: var(--rm-bg);
+    color: var(--rm-muted);
+    font-size: var(--text-xs);
+    padding: 0.35rem 0.6rem;
+    border-radius: var(--radius);
+    cursor: pointer;
+    min-width: 4.5rem;
+    text-align: center;
+  }
+  .codeblock-copy:hover {
+    background: var(--rm-surface);
+    color: var(--rm-fg, var(--rm-text, #fff));
+  }
+
+  .codeblock-pre {
+    margin: 0;
+    padding: var(--space-4);
+    overflow-x: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: var(--text-sm);
+    line-height: 1.5;
+    color: var(--rm-fg, var(--rm-text, #fff));
+  }
+</style>

--- a/apps/dashboard/src/lib/components/walkthrough/WalkthroughChecklist.svelte
+++ b/apps/dashboard/src/lib/components/walkthrough/WalkthroughChecklist.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  /** Interactive checklist for a phase; persists to localStorage and syncs with WalkthroughStep. */
+  import { onMount } from "svelte";
+  import { getProgressStore, setStepComplete, syncProgressFromStorage } from "$lib/walkthrough-progress";
+
+  export let phaseSlug = "";
+  /** Step id and label for each checklist item */
+  export let steps: { id: string; label: string }[] = [];
+
+  const progress = getProgressStore(phaseSlug);
+  $: completedCount = steps.filter((s) => $progress[s.id]).length;
+
+  onMount(() => {
+    syncProgressFromStorage(phaseSlug);
+  });
+
+  function toggle(stepId: string) {
+    const next = !$progress[stepId];
+    setStepComplete(phaseSlug, stepId, next);
+  }
+</script>
+
+<div class="walkthrough-checklist">
+  <p class="walkthrough-checklist-heading">
+    <strong>Checklist</strong>
+    {#if completedCount > 0}
+      <span class="walkthrough-checklist-count">{completedCount}/{steps.length} done</span>
+    {/if}
+  </p>
+  <ul class="walkthrough-checklist-list" role="list">
+    {#each steps as { id, label }}
+      {@const done = $progress[id]}
+      <li class="walkthrough-checklist-item">
+        <label>
+          <input type="checkbox" checked={done} on:change={() => toggle(id)} />
+          <span class="walkthrough-checklist-label">{label}</span>
+        </label>
+      </li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+  .walkthrough-checklist {
+    background: var(--rm-surface);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    margin-bottom: var(--space-6);
+  }
+  .walkthrough-checklist-heading {
+    margin: 0 0 var(--space-3);
+    font-size: var(--text-sm);
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .walkthrough-checklist-count {
+    color: var(--rm-muted);
+    font-weight: var(--font-normal);
+  }
+  .walkthrough-checklist-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .walkthrough-checklist-item {
+    margin-bottom: var(--space-2);
+  }
+  .walkthrough-checklist-item:last-child {
+    margin-bottom: 0;
+  }
+  .walkthrough-checklist-item label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    cursor: pointer;
+    font-size: var(--text-sm);
+    color: var(--rm-muted);
+  }
+  .walkthrough-checklist-item input[type="checkbox"] {
+    width: 1.125rem;
+    height: 1.125rem;
+    accent-color: var(--rm-primary);
+  }
+  .walkthrough-checklist-label {
+    flex: 1;
+  }
+</style>

--- a/apps/dashboard/src/lib/components/walkthrough/WalkthroughPhaseNav.svelte
+++ b/apps/dashboard/src/lib/components/walkthrough/WalkthroughPhaseNav.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  /** Single compact nav: Previous | Step N of M | Next. No duplicate "Next" copy. */
+  export let prev: { href: string; label: string } | null = null;
+  export let next: { href: string; label: string } | null = null;
+  export let stepOf = "";
+</script>
+
+<nav class="walkthrough-phase-nav" aria-label="Walkthrough navigation">
+  <span class="walkthrough-phase-nav-prev">
+    {#if prev}
+      <a href={prev.href}>← {prev.label}</a>
+    {:else}
+      <a href="/keys/docs/walkthrough">Walkthrough</a>
+    {/if}
+  </span>
+  <span class="walkthrough-phase-nav-step">{stepOf}</span>
+  <span class="walkthrough-phase-nav-next">
+    {#if next}
+      <a href={next.href}>{next.label} →</a>
+    {:else}
+      <span aria-hidden="true">—</span>
+    {/if}
+  </span>
+</nav>
+
+<style>
+  .walkthrough-phase-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    margin-top: var(--space-8);
+    padding-top: var(--space-4);
+    border-top: 1px solid var(--rm-border);
+    font-size: var(--text-sm);
+  }
+  .walkthrough-phase-nav-prev,
+  .walkthrough-phase-nav-next {
+    flex: 1;
+  }
+  .walkthrough-phase-nav-next {
+    text-align: right;
+  }
+  .walkthrough-phase-nav-step {
+    color: var(--rm-muted);
+    flex-shrink: 0;
+  }
+  .walkthrough-phase-nav a {
+    color: var(--rm-primary);
+    font-weight: var(--font-medium);
+  }
+</style>

--- a/apps/dashboard/src/lib/components/walkthrough/WalkthroughStep.svelte
+++ b/apps/dashboard/src/lib/components/walkthrough/WalkthroughStep.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  /** Expandable step section for walkthrough phases. Syncs with WalkthroughChecklist via progress store. */
+  import { getProgressStore, setStepComplete } from "$lib/walkthrough-progress";
+
+  export let stepId = "";
+  export let title = "";
+  export let defaultOpen = false;
+  export let phaseSlug = "";
+
+  const progress = getProgressStore(phaseSlug);
+  $: completed = $progress[stepId] === true;
+
+  function toggleComplete(e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
+    setStepComplete(phaseSlug, stepId, !completed);
+  }
+</script>
+
+<details class="walkthrough-step" open={defaultOpen} data-step-id={stepId} data-phase={phaseSlug}>
+  <summary class="walkthrough-step-summary">
+    <span class="walkthrough-step-title">{title}</span>
+    <button
+      type="button"
+      class="walkthrough-step-check"
+      aria-label={completed ? "Mark as incomplete" : "Mark complete"}
+      title={completed ? "Mark as incomplete" : "Mark complete"}
+      on:click|preventDefault|stopPropagation={toggleComplete}
+    >
+      {#if completed}
+        <span class="check-done" aria-hidden="true">✓</span>
+      {:else}
+        <span class="check-empty" aria-hidden="true">○</span>
+      {/if}
+    </button>
+  </summary>
+  <div class="walkthrough-step-body">
+    <slot />
+  </div>
+</details>
+
+<style>
+  .walkthrough-step {
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+    margin-bottom: var(--space-3);
+    background: var(--rm-surface);
+  }
+  .walkthrough-step-summary {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    cursor: pointer;
+    font-weight: var(--font-medium);
+    user-select: none;
+  }
+  .walkthrough-step-summary::-webkit-details-marker {
+    display: none;
+  }
+  .walkthrough-step-summary::marker {
+    display: none;
+  }
+  .walkthrough-step-title {
+    flex: 1;
+  }
+  .walkthrough-step-check {
+    flex-shrink: 0;
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius);
+    background: var(--rm-bg);
+    color: var(--rm-primary);
+    font-size: 1rem;
+    cursor: pointer;
+  }
+  .walkthrough-step-check:hover {
+    background: var(--rm-surface-raised);
+  }
+  .check-empty {
+    opacity: 0.5;
+  }
+  .check-done {
+    color: var(--rm-success, #22c55e);
+  }
+  .walkthrough-step-body {
+    padding: 0 var(--space-4) var(--space-4);
+    margin-top: calc(-1 * var(--space-2));
+  }
+  .walkthrough-step-body :global(.doc-table),
+  .walkthrough-step-body :global(.code-block),
+  .walkthrough-step-body :global(.codeblock),
+  .walkthrough-step-body :global(.callout),
+  .walkthrough-step-body :global(.build-agent-block) {
+    margin-left: 0;
+    margin-right: 0;
+  }
+</style>

--- a/apps/dashboard/src/lib/docs-walkthrough-nav.ts
+++ b/apps/dashboard/src/lib/docs-walkthrough-nav.ts
@@ -1,0 +1,31 @@
+/**
+ * Walkthrough phase list for docs nav. Canonical order and slugs; used by walkthrough index and phase pages for prev/next.
+ */
+export const WALKTHROUGH_PHASES = [
+  { slug: "phase-0-inventory", title: "Phase 0 — Inventory your routing", step: 1 },
+  { slug: "phase-1-install", title: "Phase 1 — Install and configure", step: 2 },
+  { slug: "phase-2-resolve", title: "Phase 2 — Resolve your first model", step: 3 },
+  { slug: "phase-3-routes", title: "Phase 3 — Add routes and fallbacks", step: 4 },
+  { slug: "phase-4-policies", title: "Phase 4 — Apply policies", step: 5 },
+  { slug: "phase-5-ui", title: "Phase 5 — Embed the UI", step: 6 },
+  { slug: "phase-6-golive", title: "Phase 6 — Go live", step: 7 },
+  { slug: "migration-paths", title: "Migration paths", step: 8 },
+  { slug: "verification-strategy", title: "Verification strategy", step: 9 },
+] as const;
+
+const BASE = "/keys/docs/walkthrough";
+
+export function getWalkthroughPrevNext(currentSlug: string): { prev: { href: string; label: string } | null; next: { href: string; label: string } | null; stepOf: string } {
+  const idx = WALKTHROUGH_PHASES.findIndex((p) => p.slug === currentSlug);
+  const total = WALKTHROUGH_PHASES.length;
+  const stepOf = `Step ${idx + 1} of ${total}`;
+  const prev =
+    idx <= 0
+      ? null
+      : { href: `${BASE}/${WALKTHROUGH_PHASES[idx - 1].slug}`, label: WALKTHROUGH_PHASES[idx - 1].title };
+  const next =
+    idx < 0 || idx >= total - 1
+      ? null
+      : { href: `${BASE}/${WALKTHROUGH_PHASES[idx + 1].slug}`, label: WALKTHROUGH_PHASES[idx + 1].title };
+  return { prev, next, stepOf };
+}

--- a/apps/dashboard/src/lib/nav-config.test.ts
+++ b/apps/dashboard/src/lib/nav-config.test.ts
@@ -43,10 +43,10 @@ describe("topbarTitle", () => {
   });
 
   it("returns Project for project detail path", () => {
-    expect(topbarTitle(base + "/projects/abc-123")).toBe("Project");
+    expect(topbarTitle(DASHBOARD_BASE + "/projects/abc-123")).toBe("Project");
   });
 
   it("returns empty string for unknown path", () => {
-    expect(topbarTitle(base + "/unknown")).toBe("");
+    expect(topbarTitle(DASHBOARD_BASE + "/unknown")).toBe("");
   });
 });

--- a/apps/dashboard/src/lib/server/auth.ts
+++ b/apps/dashboard/src/lib/server/auth.ts
@@ -108,7 +108,7 @@ export async function getSession(
     }
     const data = (await res.json()) as { user?: SessionUser; session?: unknown } | null;
     const user = data?.user ?? null;
-    return { data: user ? { user } : { user: null }, error: null };
+    return { data: user ? { user } : null, error: null };
   } catch (e) {
     return { data: null, error: e instanceof Error ? e : new Error(String(e)) };
   }
@@ -142,14 +142,14 @@ export async function proxyAuthRequest(
     method: request.method,
     headers,
     body: hasBody ? request.body : undefined,
-    duplex: hasBody ? ("half" as RequestDuplex) : undefined,
     redirect: "manual",
-  });
+    ...(hasBody && { duplex: "half" as const }),
+  } as RequestInit);
   if (res.status === 503) {
     console.error("[auth] Neon Auth returned 503 for", path, "— check NEON_AUTH_BASE_URL and that Auth is enabled in Neon Console.");
   }
   // Log 4xx body so we can see Neon's error message in Vercel logs
-  let bodyToReturn: BodyInit = res.body;
+  let bodyToReturn: BodyInit = res.body ?? "";
   if (res.status >= 400 && res.status < 500) {
     const errText = await res.text();
     console.error("[auth] Neon Auth", res.status, "for", path, "—", errText.slice(0, 600));

--- a/apps/dashboard/src/lib/server/integrations-auth.ts
+++ b/apps/dashboard/src/lib/server/integrations-auth.ts
@@ -14,6 +14,12 @@ export type IntegrationsLocals = {
   };
 };
 
+function isDbNotReadyError(e: unknown): boolean {
+  const code = (e as { code?: unknown } | null)?.code;
+  // Postgres: undefined table / undefined column (common when migrations not applied)
+  return code === "42P01" || code === "42703";
+}
+
 export async function getWorkspaceAndActor(
   locals: IntegrationsLocals
 ): Promise<{ workspaceId: string; actorId: string; actorType: string } | null> {
@@ -26,7 +32,16 @@ export async function getWorkspaceAndActor(
       actorType: "management_key",
     };
   }
-  const workspace = await getOrCreateDefaultWorkspace(locals.user.uid);
+  let workspace;
+  try {
+    workspace = await getOrCreateDefaultWorkspace(locals.user.uid);
+  } catch (e) {
+    if (isDbNotReadyError(e)) {
+      console.warn("[db] not ready (missing migrations) — treating as unauthenticated for now");
+      return null;
+    }
+    throw e;
+  }
   return {
     workspaceId: workspace.id,
     actorId: locals.user.uid,

--- a/apps/dashboard/src/lib/walkthrough-progress.ts
+++ b/apps/dashboard/src/lib/walkthrough-progress.ts
@@ -1,0 +1,64 @@
+/**
+ * Walkthrough progress: persisted checklist state per phase.
+ * Key: restormel-walkthrough-{phaseSlug} → JSON object { stepId: boolean }
+ * Used by WalkthroughChecklist and WalkthroughStep.
+ */
+
+import { writable } from "svelte/store";
+
+const PREFIX = "restormel-walkthrough-";
+
+function storageKey(phaseSlug: string): string {
+  return `${PREFIX}${phaseSlug}`;
+}
+
+export function getPhaseProgress(phaseSlug: string): Record<string, boolean> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(storageKey(phaseSlug));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.entries(parsed).filter(([, v]) => typeof v === "boolean") as [string, boolean][]
+    );
+  } catch {
+    return {};
+  }
+}
+
+const progressStores = new Map<string, ReturnType<typeof writable<Record<string, boolean>>>>();
+
+function getStore(phaseSlug: string) {
+  let s = progressStores.get(phaseSlug);
+  if (!s) {
+    s = writable(getPhaseProgress(phaseSlug));
+    progressStores.set(phaseSlug, s);
+  }
+  return s;
+}
+
+export function setStepComplete(phaseSlug: string, stepId: string, complete: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    const current = getPhaseProgress(phaseSlug);
+    const next = { ...current, [stepId]: complete };
+    localStorage.setItem(storageKey(phaseSlug), JSON.stringify(next));
+    getStore(phaseSlug).set(next);
+  } catch {
+    // ignore
+  }
+}
+
+export function isStepComplete(phaseSlug: string, stepId: string): boolean {
+  return getPhaseProgress(phaseSlug)[stepId] === true;
+}
+
+export function getProgressStore(phaseSlug: string) {
+  return getStore(phaseSlug);
+}
+
+/** Call on client mount to sync store from localStorage (e.g. after hydration). */
+export function syncProgressFromStorage(phaseSlug: string): void {
+  if (typeof window === "undefined") return;
+  getStore(phaseSlug).set(getPhaseProgress(phaseSlug));
+}

--- a/apps/dashboard/src/routes/+page.server.ts
+++ b/apps/dashboard/src/routes/+page.server.ts
@@ -3,8 +3,5 @@ import type { PageServerLoad } from "./$types";
 
 /** Server redirect for marketing home so crawlers get a 302. */
 export const load: PageServerLoad = async () => {
-  // #region agent log
-  fetch('http://127.0.0.1:7463/ingest/4d73a77a-e2c7-48aa-ae41-73a13b42405f',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4fc0f8'},body:JSON.stringify({sessionId:'4fc0f8',location:'+page.server.ts:5',message:'root load reached, redirecting to /keys',data:{env_DATABASE_URL_set:!!process.env.DATABASE_URL,env_NEON_AUTH_set:!!process.env.NEON_AUTH_BASE_URL},timestamp:Date.now(),hypothesisId:'C'})}).catch(()=>{});
-  // #endregion
   throw redirect(302, "/keys");
 };

--- a/apps/dashboard/src/routes/keys/+layout.svelte
+++ b/apps/dashboard/src/routes/keys/+layout.svelte
@@ -5,7 +5,7 @@
 
 <svelte:head>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
   <link
     href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap"
     rel="stylesheet"
@@ -14,7 +14,7 @@
 
 <div class="marketing-page">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <header class="marketing-nav" role="banner">
+  <header class="marketing-nav">
     <nav class="marketing-nav-inner" aria-label="Main">
       <a href="/" class="logo">
         <img src="/restormel-lockup-nav.svg" alt="Restormel" class="logo-img" style="height: 28px; width: auto;" />
@@ -28,10 +28,10 @@
       </ul>
     </nav>
   </header>
-  <main id="main-content" class="marketing-main" role="main">
+  <main id="main-content" class="marketing-main">
     <slot />
   </main>
-  <footer class="marketing-footer" role="contentinfo">
+  <footer class="marketing-footer">
     <div class="marketing-footer-inner">
       <div class="marketing-footer-col">
         <span class="marketing-footer-title">Product</span>

--- a/apps/dashboard/src/routes/keys/+page.svelte
+++ b/apps/dashboard/src/routes/keys/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
-  /** Restormel Keys landing — migrated from Astro (Phase B). */
+  /** Restormel Keys landing — migrated from Astro (Phase B). Code samples use vars so bundler does not resolve workspace packages. */
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+
+  const pkgKeys = "@restormel/keys";
+  const pkgReact = "@restormel/keys-react";
   const serverCode = `// app/api/chat/route.ts (Next.js App Router)
-import { createResolveMiddleware } from "@restormel/keys";
+import { createResolveMiddleware } from "${pkgKeys}";
 
 const resolve = createResolveMiddleware({
   keys: await getStoredKeys(),
@@ -20,7 +24,7 @@ export async function POST(req: Request) {
 }`;
 
   const uiCode = `// app/settings/page.tsx
-import { KeyManager } from "@restormel/keys-react";
+import { KeyManager } from "${pkgReact}";
 
 export default function Settings() {
   return (
@@ -47,7 +51,8 @@ export default function Settings() {
       </p>
       <p class="hero-who">For AI SaaS builders, open-source maintainers, and small teams that need routing and end-user BYOK without running a gateway or rewriting key logic from scratch.</p>
       <div class="hero-ctas">
-        <a href="/keys/docs" class="btn btn-primary">Get started</a>
+        <a href="/keys/docs/walkthrough/phase-0-inventory" class="btn btn-primary btn-cta-hero">Start the walkthrough</a>
+        <a href="/keys/docs" class="btn btn-secondary">Docs</a>
         <a href="https://github.com/Allotment-Technology-Ltd/restormel-keys" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
     </div>
@@ -88,11 +93,11 @@ export default function Settings() {
       <div class="code-split">
         <div class="code-pane">
           <span class="code-label">Server</span>
-          <div class="code-block"><pre><code>{serverCode}</code></pre></div>
+          <CodeBlock language="ts" code={serverCode} />
         </div>
         <div class="code-pane">
           <span class="code-label">React / Next.js</span>
-          <div class="code-block"><pre><code>{uiCode}</code></pre></div>
+          <CodeBlock language="tsx" code={uiCode} />
         </div>
       </div>
     </div>
@@ -249,6 +254,18 @@ export default function Settings() {
   .btn-primary:hover {
     filter: brightness(1.1);
   }
+  .btn-cta-hero {
+    padding: var(--space-4) var(--space-8);
+    font-size: var(--text-xl);
+    font-weight: var(--font-semibold);
+    min-width: 16rem;
+    text-align: center;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+  }
+  .btn-cta-hero:hover {
+    filter: brightness(1.1);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+  }
   .btn-secondary {
     background: var(--rm-surface-raised);
     color: var(--rm-text);
@@ -303,20 +320,6 @@ export default function Settings() {
     color: var(--rm-dim);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-  }
-  .code-block {
-    background: var(--rm-surface);
-    border: 1px solid var(--rm-border);
-    border-radius: var(--radius-md);
-    overflow: auto;
-    font-size: var(--text-sm);
-  }
-  .code-block :global(pre) {
-    margin: 0;
-    padding: var(--space-5);
-  }
-  .code-block :global(code) {
-    font-family: var(--rm-font-ui);
   }
   .frameworks-copy {
     font-size: var(--text-base);

--- a/apps/dashboard/src/routes/keys/dashboard/+layout.svelte
+++ b/apps/dashboard/src/routes/keys/dashboard/+layout.svelte
@@ -169,10 +169,6 @@
     filter: brightness(1.1);
     text-decoration: none;
   }
-  .auth-prompt {
-    margin: 0 0 var(--space-4);
-    color: var(--rm-muted);
-  }
   .auth-error {
     margin: 0 0 var(--space-4);
     padding: var(--space-3) var(--space-4);

--- a/apps/dashboard/src/routes/keys/dashboard/+page.svelte
+++ b/apps/dashboard/src/routes/keys/dashboard/+page.svelte
@@ -104,10 +104,6 @@
     font-size: var(--text-sm);
     margin: 0 0 var(--space-4);
   }
-  .empty {
-    color: var(--rm-muted);
-    margin: 0 0 var(--space-4);
-  }
   .project-list {
     list-style: none;
     padding: 0;

--- a/apps/dashboard/src/routes/keys/dashboard/api/policies/[id]/+server.ts
+++ b/apps/dashboard/src/routes/keys/dashboard/api/policies/[id]/+server.ts
@@ -20,7 +20,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
   } catch {
     return json({ error: "Invalid JSON" }, { status: 400 });
   }
-  const updates: Parameters<typeof updatePolicy>[3] = {};
+  const updates: Parameters<typeof updatePolicy>[2] = {};
   if (typeof body.name === "string") updates.name = body.name.trim();
   if (typeof body.type === "string") updates.type = body.type.trim();
   if (typeof body.status === "string") updates.status = body.status.trim();

--- a/apps/dashboard/src/routes/keys/dashboard/login/+page.svelte
+++ b/apps/dashboard/src/routes/keys/dashboard/login/+page.svelte
@@ -42,11 +42,6 @@
   .login-form {
     margin: 0 0 1.5rem;
   }
-  .login-error {
-    color: #c95c5c;
-    font-size: 0.875rem;
-    margin: 0 0 1rem;
-  }
   .btn {
     display: inline-block;
     padding: 0.5rem 1rem;

--- a/apps/dashboard/src/routes/keys/dashboard/models/+page.svelte
+++ b/apps/dashboard/src/routes/keys/dashboard/models/+page.svelte
@@ -129,7 +129,7 @@
 
 {#if selectedId}
   <div class="drawer-backdrop" role="presentation" onclick={closeDetail}></div>
-  <aside class="drawer" role="dialog" aria-labelledby="drawer-title" aria-modal="true">
+  <div class="drawer" role="dialog" aria-labelledby="drawer-title" aria-modal="true">
     <div class="drawer-header">
       <h2 id="drawer-title">Model detail</h2>
       <button type="button" class="btn-close" onclick={closeDetail} aria-label="Close">×</button>
@@ -138,7 +138,7 @@
       <a href={DASHBOARD_BASE + "/models/" + selectedId} class="btn btn-secondary">Open full page</a>
       <p class="muted">Full detail and provider variants on the model page.</p>
     </div>
-  </aside>
+  </div>
 {/if}
 
 <style>

--- a/apps/dashboard/src/routes/keys/dashboard/models/[id]/+page.svelte
+++ b/apps/dashboard/src/routes/keys/dashboard/models/[id]/+page.svelte
@@ -44,9 +44,9 @@
 
 {#if data.error || !data.model}
   <p class="error-msg" role="alert">{data.error ?? "Model not found."}</p>
-  <p><a href={base + "/models"} class="back-link">← Back to Model catalog</a></p>
+  <p><a href={DASHBOARD_BASE + "/models"} class="back-link">← Back to Model catalog</a></p>
 {:else}
-  <p><a href={base + "/models"} class="back-link">← Back to Model catalog</a></p>
+  <p><a href={DASHBOARD_BASE + "/models"} class="back-link">← Back to Model catalog</a></p>
   <h1 class="page-title">{data.model.canonicalName}</h1>
   <p class="page-desc">
     <span class="lifecycle-badge lifecycle-{lifecycleBadge(data.model.lifecycleState)}">
@@ -87,7 +87,7 @@
       {/if}
       {#if data.model.replacementModelId}
         <dt>Replacement</dt>
-        <dd><a href={base + "/models/" + data.model.replacementModelId}>{data.model.replacementModelId}</a></dd>
+        <dd><a href={DASHBOARD_BASE + "/models/" + data.model.replacementModelId}>{data.model.replacementModelId}</a></dd>
       {/if}
       <dt>Source</dt>
       <dd>{data.model.sourceLastVerifiedAt != null ? "Last verified: " + formatDate(data.model.sourceLastVerifiedAt) : "Not yet verified"}</dd>
@@ -102,7 +102,7 @@
       <h2 id="migration-heading" class="section-title">Migration</h2>
       <p class="section-desc">
         {#if data.model.replacementModelId}
-          Consider migrating to <a href={base + "/models/" + data.model.replacementModelId}>{data.model.replacementModelId}</a>.
+          Consider migrating to <a href={DASHBOARD_BASE + "/models/" + data.model.replacementModelId}>{data.model.replacementModelId}</a>.
         {/if}
         See <a href={DASHBOARD_BASE + "/lifecycle"}>Lifecycle & Migrations</a> for guidance.
       </p>

--- a/apps/dashboard/src/routes/keys/dashboard/policies/[id]/+page.svelte
+++ b/apps/dashboard/src/routes/keys/dashboard/policies/[id]/+page.svelte
@@ -25,7 +25,7 @@
     saving = true;
     saveError = "";
     try {
-      const res = await fetch(`${base}/api/policies/${data.policy.id}`, {
+      const res = await fetch(`${DASHBOARD_BASE}/api/policies/${data.policy.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: editStatus }),

--- a/apps/dashboard/src/routes/keys/dashboard/projects/[id]/routes/+page.svelte
+++ b/apps/dashboard/src/routes/keys/dashboard/projects/[id]/routes/+page.svelte
@@ -40,7 +40,7 @@
     creating = true;
     createError = "";
     try {
-      const res = await fetch(`${base}/api/projects/${data.project.id}/routes`, {
+      const res = await fetch(`${DASHBOARD_BASE}/api/projects/${data.project.id}/routes`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/apps/dashboard/src/routes/keys/dashboard/routes/+page.svelte
+++ b/apps/dashboard/src/routes/keys/dashboard/routes/+page.svelte
@@ -20,7 +20,7 @@
     title="No projects yet"
     description="Create a project first. Routes belong to a project and an environment."
   >
-    <a href={base + "/projects"} class="btn btn-primary">Go to Projects</a>
+    <a href={DASHBOARD_BASE + "/projects"} class="btn btn-primary">Go to Projects</a>
   </EmptyState>
 {:else}
   <section class="section" aria-labelledby="projects-heading">

--- a/apps/dashboard/src/routes/keys/docs/+layout.svelte
+++ b/apps/dashboard/src/routes/keys/docs/+layout.svelte
@@ -11,6 +11,7 @@
   <nav class="docs-nav">
     <a href="/keys">Keys</a>
     <a href="/keys/docs">Overview</a>
+    <a href="/keys/docs/walkthrough">Walkthrough</a>
     <a href="/keys/docs/compatibility">Compatibility</a>
     <a href="/keys/docs/cloud-api">Cloud API</a>
     <a href={DASHBOARD_BASE}>Dashboard</a>
@@ -42,5 +43,61 @@
   .docs-main {
     flex: 1;
     padding: var(--space-6);
+  }
+
+  /* Shared callout styles — each type has a distinct tint and border so cards don't blend into the page */
+  .docs-main :global(.callout) {
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--radius-md);
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+    border: 1px solid var(--rm-border);
+    border-left-width: 4px;
+  }
+  .docs-main :global(.callout a) {
+    color: var(--rm-primary);
+  }
+  .docs-main :global(.callout strong:first-of-type) {
+    font-weight: 600;
+  }
+  .docs-main :global(.callout-tip) {
+    background: color-mix(in oklab, var(--rm-primary) 10%, var(--rm-surface));
+    border-color: var(--rm-border);
+    border-left-color: var(--rm-primary);
+    color: var(--rm-muted);
+  }
+  .docs-main :global(.callout-tip strong:first-of-type) {
+    color: var(--rm-primary);
+  }
+  .docs-main :global(.callout-note) {
+    background: color-mix(in oklab, var(--rm-muted) 14%, var(--rm-surface));
+    border-color: var(--rm-border);
+    border-left-color: var(--rm-muted);
+    color: var(--rm-muted);
+  }
+  .docs-main :global(.callout-note strong:first-of-type) {
+    color: var(--rm-text, currentColor);
+  }
+  .docs-main :global(.callout-pitfall) {
+    background: color-mix(in oklab, var(--rm-warning, #b45309) 12%, var(--rm-surface));
+    border-color: color-mix(in oklab, var(--rm-warning, #b45309) 40%, transparent);
+    border-left-color: var(--rm-warning, #b45309);
+    border-left-width: 4px;
+    color: var(--rm-muted);
+    font-weight: var(--font-medium);
+  }
+  .docs-main :global(.callout-pitfall strong) {
+    color: var(--rm-warning, #b45309);
+  }
+  .docs-main :global(.callout-security) {
+    background: color-mix(in oklab, var(--rm-danger, #b91c1c) 12%, var(--rm-surface));
+    border-color: color-mix(in oklab, var(--rm-danger, #b91c1c) 40%, transparent);
+    border-left-color: var(--rm-danger, #b91c1c);
+    border-left-width: 4px;
+    color: var(--rm-muted);
+    font-weight: var(--font-medium);
+  }
+  .docs-main :global(.callout-security strong) {
+    color: var(--rm-danger, #b91c1c);
   }
 </style>

--- a/apps/dashboard/src/routes/keys/docs/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  /** Docs overview — ported from Starlight index.md */
+  /** Docs overview */
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
 </script>
 
 <svelte:head>
@@ -15,7 +16,7 @@
 
   <h2>Start with Next.js</h2>
   <p>Using <strong>Next.js App Router</strong>? Install the core plus React and Web Components, then add KeyManager and your key storage. Full path: <a href="/keys/docs/compatibility">Framework compatibility</a>.</p>
-  <pre class="code-block"><code>pnpm add @restormel/keys @restormel/keys-react @restormel/keys-elements</code></pre>
+  <CodeBlock language="bash" code="pnpm add @restormel/keys @restormel/keys-react @restormel/keys-elements" />
 
   <h2>Pick your framework</h2>
   <p>One core; different wrappers. Use the headless API for resolution and cost on the server; add UI (KeyManager, ModelSelector, CostEstimator) where it fits.</p>
@@ -34,6 +35,7 @@
 
   <h2>Quick links</h2>
   <ul>
+    <li><a href="/keys/docs/walkthrough">Walkthrough</a> — step-by-step integration (Phase 0–6)</li>
     <li><a href="/keys/docs/cloud-api">Cloud API</a> — API reference, gateway URL, and Developer Portal</li>
     <li><a href="/keys">Keys landing</a> — what Keys is, modes, comparison, pricing</li>
     <li><a href="/keys/pricing">Pricing</a> — tiers and FAQ</li>
@@ -74,16 +76,6 @@
   }
   .doc-content li {
     margin-bottom: var(--space-2);
-  }
-  .code-block {
-    background: var(--rm-surface);
-    border: 1px solid var(--rm-border);
-    border-radius: var(--radius-md);
-    padding: var(--space-4);
-    font-family: var(--rm-font-ui);
-    font-size: var(--text-sm);
-    overflow-x: auto;
-    margin: 0 0 var(--space-4);
   }
   .doc-table {
     width: 100%;

--- a/apps/dashboard/src/routes/keys/docs/cloud-api/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/cloud-api/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  /** Cloud API doc — ported from Starlight cloud-api.md */
+  /** Cloud API doc */
 </script>
 
 <svelte:head>
@@ -14,7 +14,7 @@
   <h2>Where to use it</h2>
   <ul>
     <li><strong>API reference and Try it:</strong> <a href="https://restormel-keys-gateway-main-bc13eba.zuplo.site" target="_blank" rel="noopener noreferrer">Restormel Keys Developer Portal</a> — full endpoint list, request/response schemas, and interactive “Try it” with a consumer key.</li>
-    <li><strong>Gateway base URL (for API calls):</strong> <code>https://restormel-keys-gateway-main-bc13eba.zuplo.app</code> — call <code>/api/health</code>, <code>/api/projects</code>, <code>/api/projects/{id}</code>, <code>/api/projects/{id}/keys</code>. The gateway root (<code>/</code>) is not a page; use these paths.</li>
+    <li><strong>Gateway base URL (for API calls):</strong> <code>https://restormel-keys-gateway-main-bc13eba.zuplo.app</code> — call <code>/api/health</code>, <code>/api/projects</code>, <code>/api/projects/{'{'}id{'}'}</code>, <code>/api/projects/{'{'}id{'}'}/keys</code>. The gateway root (<code>/</code>) is not a page; use these paths.</li>
     <li><strong>Dashboard:</strong> <a href="/keys/dashboard">Dashboard</a> — <a href="/keys/dashboard/login">Sign in</a>, create projects, and create the <strong>backend</strong> API key that the gateway uses when forwarding to the Keys backend.</li>
   </ul>
 

--- a/apps/dashboard/src/routes/keys/docs/compatibility/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/compatibility/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  /** Framework compatibility — ported from Starlight compatibility.md */
+  /** Framework compatibility */
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
 </script>
 
 <svelte:head>
@@ -28,19 +29,19 @@
 
   <h2>Install paths</h2>
   <p><strong>Headless only (no UI):</strong></p>
-  <pre class="code-block"><code>pnpm add @restormel/keys</code></pre>
+  <CodeBlock language="bash" code="pnpm add @restormel/keys" />
 
   <p><strong>Next.js or React (KeyManager, ModelSelector, CostEstimator):</strong></p>
-  <pre class="code-block"><code>pnpm add @restormel/keys @restormel/keys-react @restormel/keys-elements</code></pre>
+  <CodeBlock language="bash" code="pnpm add @restormel/keys @restormel/keys-react @restormel/keys-elements" />
 
   <p><strong>SvelteKit (native Svelte components):</strong></p>
-  <pre class="code-block"><code>pnpm add @restormel/keys @restormel/keys-svelte</code></pre>
+  <CodeBlock language="bash" code="pnpm add @restormel/keys @restormel/keys-svelte" />
 
   <p><strong>Web Components (Astro, vanilla HTML, or any framework):</strong></p>
-  <pre class="code-block"><code>pnpm add @restormel/keys @restormel/keys-elements</code></pre>
+  <CodeBlock language="bash" code="pnpm add @restormel/keys @restormel/keys-elements" />
 
   <p><strong>CLI (init, add keys, validate, doctor):</strong></p>
-  <pre class="code-block"><code>pnpm add -D @restormel/keys-cli</code></pre>
+  <CodeBlock language="bash" code="pnpm add -D @restormel/keys-cli" />
 
   <h2>When to use which</h2>
   <ul>
@@ -93,16 +94,6 @@
   }
   .doc-content li {
     margin-bottom: var(--space-2);
-  }
-  .code-block {
-    background: var(--rm-surface);
-    border: 1px solid var(--rm-border);
-    border-radius: var(--radius-md);
-    padding: var(--space-4);
-    font-family: var(--rm-font-ui);
-    font-size: var(--text-sm);
-    overflow-x: auto;
-    margin: 0 0 var(--space-4);
   }
   .doc-table {
     width: 100%;

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/+page.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  /** Walkthrough — integration journey entry. Content aligned with docs/walkthrough/00-index.md. */
+  import { DASHBOARD_BASE } from "$lib/dashboard-base";
+</script>
+
+<svelte:head>
+  <title>Walkthrough — Restormel Keys</title>
+  <meta name="description" content="Step-by-step integration walkthrough for Restormel Keys: install, resolve, routes, policies, UI, go live." />
+</svelte:head>
+
+<div class="doc-content">
+  <h1>Integration walkthrough</h1>
+  <p class="doc-tagline">From "I have an AI app" to "my app resolves, routes, enforces policies, and shows embeddable UI through Restormel Keys."</p>
+
+  <p>This walkthrough is the primary onboarding journey. It takes you through install, first resolve call, routes and fallbacks, policies, embeddable UI, and go-live. Use it with the Dashboard and Cloud API (Zuplo) as you go.</p>
+
+  <h2>Before you begin</h2>
+  <p>Prerequisites: an existing AI-powered app, a Restormel account, and your routing inventory (what you use today for model selection).</p>
+
+  <h2>Phases</h2>
+  <ol class="walkthrough-steps">
+    <li><a href="/keys/docs/walkthrough/phase-0-inventory"><strong>Phase 0 — Inventory</strong></a> — Audit existing routing and decide what to remove, keep, or wrap.</li>
+    <li><a href="/keys/docs/walkthrough/phase-1-install"><strong>Phase 1 — Install and configure</strong></a> — Packages, dashboard project, Gateway Key, <code>keys doctor</code> (framework and config; Cloud env is verified in Phase 2).</li>
+    <li><a href="/keys/docs/walkthrough/phase-2-resolve"><strong>Phase 2 — Resolve your first model</strong></a> — One resolve call from your backend; verify <code>providerType</code> and <code>modelId</code> in the response.</li>
+    <li><a href="/keys/docs/walkthrough/phase-3-routes"><strong>Phase 3 — Add routes and fallbacks</strong></a> — Create routes with steps in the Dashboard; configure fallback chain; wire route IDs.</li>
+    <li><a href="/keys/docs/walkthrough/phase-4-policies"><strong>Phase 4 — Apply policies</strong></a> — Model allowlist, deprecated-model block, budget cap; use the evaluate endpoint with a <strong>Management Key</strong> (workspace-scoped, not the project Gateway Key).</li>
+    <li><a href="/keys/docs/walkthrough/phase-5-ui"><strong>Phase 5 — Embed the UI</strong></a> — ModelSelector and optional KeyManager; policy-filtered model list via a server-side proxy.</li>
+    <li><a href="/keys/docs/walkthrough/phase-6-golive"><strong>Phase 6 — Go live</strong></a> — Parallel run, cutover, smoke test, legacy code removal.</li>
+    <li><a href="/keys/docs/walkthrough/migration-paths"><strong>Migration paths</strong></a> — LiteLLM, Portkey, OpenRouter, custom.</li>
+    <li><a href="/keys/docs/walkthrough/verification-strategy"><strong>Verification strategy</strong></a> — Dashboard, CLI, smoke tests; ongoing monitoring and CI.</li>
+  </ol>
+
+  <h2>Auth at a glance</h2>
+  <ul>
+    <li><strong>Gateway Key</strong> — Resolve API, project-scoped; use in app env vars for your backend.</li>
+    <li><strong>Management Key</strong> — Policies evaluate, workspace-scoped; backend or automation only; never in the browser.</li>
+    <li><strong>Session</strong> — Dashboard UI (Sign in with GitHub).</li>
+  </ul>
+
+  <h2>Next</h2>
+  <p><a href="/keys/docs/compatibility">Framework compatibility</a> for install commands. <a href={DASHBOARD_BASE}>Dashboard</a> to create a project and generate a Gateway Key. <a href="/keys/docs/cloud-api">Cloud API</a> for gateway URL and Zuplo.</p>
+</div>
+
+<style>
+  .doc-content {
+    max-width: var(--rm-container-narrow);
+  }
+  .doc-tagline {
+    font-size: var(--text-lg);
+    color: var(--rm-muted);
+    margin: 0 0 var(--space-6);
+  }
+  .doc-content h1 {
+    font-family: var(--rm-font-display);
+    font-size: var(--text-2xl);
+    margin: 0 0 var(--space-2);
+  }
+  .doc-content h2 {
+    font-size: var(--text-lg);
+    margin: var(--space-6) 0 var(--space-2);
+  }
+  .walkthrough-steps {
+    padding-left: var(--space-6);
+    margin: 0 0 var(--space-4);
+  }
+  .walkthrough-steps li {
+    margin-bottom: var(--space-2);
+  }
+</style>

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/migration-paths/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/migration-paths/+page.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+  /** Migration paths. Progressive disclosure: checklist + expandable sections. */
+  import { DASHBOARD_BASE } from "$lib/dashboard-base";
+  import { getWalkthroughPrevNext } from "$lib/docs-walkthrough-nav";
+  import WalkthroughChecklist from "$lib/components/walkthrough/WalkthroughChecklist.svelte";
+  import WalkthroughStep from "$lib/components/walkthrough/WalkthroughStep.svelte";
+  import WalkthroughPhaseNav from "$lib/components/walkthrough/WalkthroughPhaseNav.svelte";
+
+  const { prev, next, stepOf } = getWalkthroughPrevNext("migration-paths");
+  const phaseSlug = "migration-paths";
+
+  const migrationSteps = [
+    { id: "principle", label: "Migration principle: the strangler pattern" },
+    { id: "variant-a", label: "Variant A: custom routing code" },
+    { id: "variant-b", label: "Variant B: LiteLLM" },
+    { id: "variant-c", label: "Variant C: Portkey" },
+    { id: "variant-d", label: "Variant D: OpenRouter" },
+    { id: "comparison", label: "Comparison: what each source gives you" },
+    { id: "strangler", label: "The safe strangler approach in detail" },
+    { id: "checkpoint", label: "Checkpoint" },
+  ];
+</script>
+
+<svelte:head>
+  <title>Migration paths — Restormel Keys</title>
+  <meta name="description" content="Strangler pattern for migrating from custom routing, LiteLLM, Portkey, or OpenRouter to Restormel Keys." />
+</svelte:head>
+
+<div class="doc-content">
+  <p class="doc-meta"><span class="doc-step">{stepOf}</span></p>
+  <h1>Migration paths</h1>
+  <p class="doc-prereqs">
+    <strong>Time:</strong> Varies by source system<br />
+    <strong>Prerequisites:</strong> Familiarity with your current routing system, a Restormel Keys account<br />
+    <strong>You'll need:</strong> Access to your current gateway/proxy config, your app's codebase, and the <a href={DASHBOARD_BASE}>Dashboard</a>
+  </p>
+
+  <p>This page covers migration from four starting points: custom routing code, LiteLLM, Portkey, and OpenRouter. Each variant follows the same principle: <strong>strangler pattern</strong> — run old and new in parallel, shift traffic incrementally, verify, then retire the old system.</p>
+  <p>The walkthrough phases (0–6) are framework-agnostic. This page maps each migration source to the phases, highlights what's different, and provides source-specific prompts.</p>
+
+  <WalkthroughStep stepId="principle" title="Migration principle: the strangler pattern" defaultOpen={true} phaseSlug={phaseSlug}>
+  <p>Your app sends 100% traffic to the old routing system (LiteLLM, Portkey, or custom). A feature flag gates Restormel resolve; when enabled, some traffic takes the new path to the AI provider. Both paths can hit the provider until you cut over.</p>
+  <ol>
+    <li><strong>Install</strong> Restormel Keys alongside your existing system (Phase 1). Nothing changes yet.</li>
+    <li><strong>Wire</strong> the resolve call behind a feature flag (Phase 2). Old system still handles 100%.</li>
+    <li><strong>Shift</strong> a small percentage of traffic to Restormel (Phase 6, Step 6.2). Both systems run.</li>
+    <li><strong>Verify</strong> — compare outcomes, latency, and errors between old and new paths.</li>
+    <li><strong>Cut over</strong> — move all traffic to Restormel. Old system is idle.</li>
+    <li><strong>Remove</strong> — decommission the old system after a burn-in period.</li>
+  </ol>
+  <p>At no point do you rip out the old system before the new one is proven. The feature flag (Phase 0, Step 0.5) is your safety net throughout.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="variant-a" title="Variant A — I have custom routing code" phaseSlug={phaseSlug}>
+  <p>This is the default path the walkthrough is written for. Your app has bespoke if/else, config files, or a small routing module that picks providers.</p>
+  <p><strong>What's different:</strong> Nothing. Follow Phases 0–6 as written.</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Phase</th><th>What you do</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>0</td><td>Inventory your custom files (router, fallback, model picker, BYOK settings)</td></tr>
+      <tr><td>1</td><td>Install packages, create project</td></tr>
+      <tr><td>2</td><td>Wire resolve alongside your custom router via feature flag</td></tr>
+      <tr><td>3</td><td>Move your fallback chain config into dashboard routes</td></tr>
+      <tr><td>4</td><td>Move your model allowlists into dashboard policies</td></tr>
+      <tr><td>5</td><td>Replace your custom model picker with ModelSelector</td></tr>
+      <tr><td>6</td><td>Shift traffic, verify, remove custom code</td></tr>
+    </tbody>
+  </table>
+  <div class="callout callout-note">
+    <strong>Note</strong> — Custom routing code is often spread across many files with implicit dependencies. Phase 0 (inventory) is especially important; don't skip it.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="variant-b" title="Variant B — I'm using LiteLLM" phaseSlug={phaseSlug}>
+  <p>LiteLLM is a proxy server that normalises provider APIs. You call LiteLLM's endpoint and it forwards to the configured provider. Common setup: Docker container running LiteLLM with a config file defining models, fallbacks, and provider keys.</p>
+  <p><strong>What Restormel replaces:</strong> LiteLLM's routing and fallback logic → Restormel routes and steps. LiteLLM's model config → Restormel dashboard (routes, policies, model catalog). LiteLLM's proxy endpoint → your app calls providers directly using the resolve result.</p>
+  <p><strong>What Restormel does NOT replace:</strong> LiteLLM's request/response normalisation if you depend on its unified schema. If you need this, keep LiteLLM as a normalisation layer and have Restormel decide which model LiteLLM should use.</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Phase</th><th>LiteLLM-specific notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>0</td><td>Inventory: your LiteLLM config, the Docker/process setup, and every place your app calls the LiteLLM proxy. Classify as "REMOVE" (call providers directly) or "WRAP" (keep LiteLLM as normalisation layer with Restormel doing routing).</td></tr>
+      <tr><td>1</td><td>Install Restormel packages. No change to LiteLLM yet.</td></tr>
+      <tr><td>2</td><td>Wire Restormel resolve. If keeping LiteLLM: resolve returns the model, you pass it to LiteLLM. If removing: resolve returns the provider, you call the provider SDK directly.</td></tr>
+      <tr><td>3</td><td>Translate LiteLLM fallback settings into dashboard routes. Each LiteLLM fallback model becomes a step in a Restormel route.</td></tr>
+      <tr><td>4</td><td>Translate any LiteLLM allowed_models or budget settings into Restormel policies.</td></tr>
+      <tr><td>5</td><td>If LiteLLM had no UI, this is net-new. If it did, replace with Restormel ModelSelector.</td></tr>
+      <tr><td>6</td><td>Shift traffic. When 100% is on Restormel: stop the LiteLLM container, remove config, remove Docker/process config.</td></tr>
+    </tbody>
+  </table>
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: migrate-from-litellm</h3>
+    <p><strong>Context docs</strong> (adapt for your project): this page (Variant B); <a href="/keys/docs/walkthrough/phase-0-inventory">Phase 0 — Inventory</a>; <a href="/keys/docs/walkthrough/phase-3-routes">Phase 3 — Routes</a>; <a href="/keys/docs/walkthrough/phase-4-policies">Phase 4 — Policies</a>.</p>
+    <p><strong>Goal:</strong> Inventory the LiteLLM integration and produce a migration plan to Restormel Keys. Locate config; extract models, fallback order, allowed/blocked models, budget settings, env vars (no values). Map every LiteLLM feature to Restormel (route steps, fallback_chain, model_allowlist, budget_cap, provider credentials). Decide: remove LiteLLM entirely or keep as normalisation layer. Write the plan to a doc (e.g. <code>docs/restormel-integration/01-litellm-migration.md</code>).</p>
+    <p><strong>DO NOT:</strong> Remove LiteLLM or its config yet (plan only). Copy real API keys into the migration doc. Assume features that aren't actually configured.</p>
+    <p><strong>Gate:</strong> A migration plan document exists mapping every LiteLLM feature to its Restormel equivalent, with a decision on whether to keep LiteLLM as a normalisation layer or remove it entirely.</p>
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="variant-c" title="Variant C — I'm using Portkey" phaseSlug={phaseSlug}>
+  <p>Portkey is a gateway with routing, fallbacks, caching, and observability. You call Portkey's endpoint with a config header that specifies routing strategy.</p>
+  <p><strong>What Restormel replaces:</strong> Portkey's routing configs → Restormel routes and steps. Portkey's fallback strategies → Restormel <code>fallback_chain</code> route mode. Portkey's model restrictions → Restormel policies.</p>
+  <p><strong>What Restormel does NOT replace:</strong> Portkey's request caching (use a separate caching layer if needed). Portkey's observability/tracing (use your existing tracing).</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Phase</th><th>Portkey-specific notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>0</td><td>Inventory: Portkey configs (JSON headers or API configs), the Portkey API key, every place your app calls the Portkey API or uses the Portkey SDK.</td></tr>
+      <tr><td>1</td><td>Install Restormel packages alongside Portkey.</td></tr>
+      <tr><td>2</td><td>Wire Restormel resolve. Your app calls resolve first, then makes the provider call directly. Feature flag gates which path runs.</td></tr>
+      <tr><td>3</td><td>Translate Portkey routing configs (provider order, fallback strategy) into dashboard routes with steps.</td></tr>
+      <tr><td>4</td><td>Translate any Portkey model restrictions or budget controls into Restormel policies.</td></tr>
+      <tr><td>5</td><td>Embed Restormel UI. Portkey has no embeddable BYOK UI — this is net-new.</td></tr>
+      <tr><td>6</td><td>Shift traffic. When 100% is on Restormel: remove Portkey SDK, delete Portkey API key, cancel Portkey subscription if applicable.</td></tr>
+    </tbody>
+  </table>
+  <p><strong>Key difference from LiteLLM:</strong> Portkey configs are typically JSON objects passed as headers or configured via their dashboard/SDK. Extract the routing logic from those configs manually.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="variant-d" title="Variant D — I'm using OpenRouter" phaseSlug={phaseSlug}>
+  <p>OpenRouter is a unified API that routes requests to multiple providers with a single endpoint. You call the OpenRouter API with a model name, and OpenRouter handles provider selection.</p>
+  <p><strong>What Restormel replaces:</strong> OpenRouter's implicit provider routing → Restormel explicit routes and steps (you control exactly which provider handles each model). OpenRouter's model selection → Restormel ModelSelector with policy constraints.</p>
+  <p><strong>What Restormel does NOT replace:</strong> OpenRouter's access to providers you don't have direct accounts with. If you use OpenRouter for that, you may keep OpenRouter as a provider within Restormel's routing (a step in a route that calls OpenRouter).</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Phase</th><th>OpenRouter-specific notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>0</td><td>Inventory: every place your app calls the OpenRouter API, the OpenRouter API key, any model-specific logic.</td></tr>
+      <tr><td>1</td><td>Install Restormel packages. Set up direct provider accounts (OpenAI, Anthropic, Google) for the models you use — or keep OpenRouter as a "provider" in your route.</td></tr>
+      <tr><td>2</td><td>Wire resolve. The resolve result tells you which provider to call. If keeping OpenRouter as a provider, add it as a custom provider in your config.</td></tr>
+      <tr><td>3</td><td>Create routes. If you previously relied on OpenRouter to pick the cheapest provider for a given model, replicate that as explicit route steps.</td></tr>
+      <tr><td>4</td><td>Add policies. OpenRouter has no policy concept — this is net-new governance.</td></tr>
+      <tr><td>5</td><td>Embed ModelSelector. OpenRouter has no embeddable UI — this is net-new.</td></tr>
+      <tr><td>6</td><td>Shift traffic. When 100% is on Restormel: remove OpenRouter SDK/API calls, revoke OpenRouter API key if no longer needed.</td></tr>
+    </tbody>
+  </table>
+  <p><strong>Key difference:</strong> OpenRouter abstracts away provider choice entirely. Moving to Restormel means you take explicit control of which provider handles each request. More work, but full visibility and policy control.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="comparison" title="Comparison: what each source gives you that Restormel doesn't" phaseSlug={phaseSlug}>
+  <table class="doc-table doc-table-wide">
+    <thead>
+      <tr><th>Feature</th><th>LiteLLM</th><th>Portkey</th><th>OpenRouter</th><th>Restormel approach</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Request/response normalisation</td><td>Yes (proxy)</td><td>Yes (proxy)</td><td>Yes (proxy)</td><td>No — call providers directly with their SDKs. Use Restormel for routing only.</td></tr>
+      <tr><td>Request caching</td><td>Plugin</td><td>Yes</td><td>No</td><td>Not in scope — use a caching layer (Redis, CDN, etc.)</td></tr>
+      <tr><td>Observability / tracing</td><td>Plugin</td><td>Yes</td><td>Basic</td><td>Not in scope — use your existing tracing</td></tr>
+      <tr><td>Access to providers you don't have accounts with</td><td>No</td><td>No</td><td>Yes</td><td>No — you need direct provider accounts (or keep OpenRouter as a step)</td></tr>
+      <tr><td>Embeddable BYOK UI</td><td>No</td><td>No</td><td>No</td><td><strong>Yes</strong> — KeyManager, ModelSelector</td></tr>
+      <tr><td>Policy enforcement (allowlists, budgets)</td><td>Partial</td><td>Partial</td><td>No</td><td><strong>Yes</strong> — first-class policies in the dashboard</td></tr>
+      <tr><td>Library-first (no proxy/container)</td><td>SDK only</td><td>No</td><td>No</td><td><strong>Yes</strong> — headless core, no infrastructure required</td></tr>
+    </tbody>
+  </table>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="strangler" title="The safe strangler approach in detail" phaseSlug={phaseSlug}>
+  <p>Regardless of your source system, the sequence is: Week 1 — install Restormel alongside the old system. Week 1–2 — wire resolve behind a feature flag. Week 2 — configure routes and policies in the dashboard. Week 2–3 — send 5% of traffic through Restormel. If errors, fix and retry at 5%; if no errors, increase to 25%, then 50%, then 100%. Burn-in for one release cycle (1–2 weeks), then remove the old system.</p>
+  <p><strong>Timeline:</strong> Most teams complete the migration in 2–3 weeks. The burn-in period before removing the old system is typically one release cycle.</p>
+  <div class="callout callout-tip">
+    <strong>Rollback</strong> — At any point, flip the feature flag to <code>false</code> and 100% of traffic returns to the old system instantly. No code change, no deployment — just an env var.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="checkpoint" title="Checkpoint" phaseSlug={phaseSlug}>
+  <p>You now have: a clear mapping from your source system (custom, LiteLLM, Portkey, or OpenRouter) to the walkthrough phases; a strangler approach that lets you migrate incrementally with instant rollback; source-specific notes on what Restormel replaces and what it doesn't; and (if LiteLLM) a build-agent prompt for producing a migration plan document.</p>
+  <p><strong>Next:</strong> <a href="/keys/docs/walkthrough/verification-strategy">Verification strategy</a> — ongoing checks for dashboard, CLI, and smoke tests after integration.</p>
+  </WalkthroughStep>
+
+  <p><strong>Checkpoint checklist:</strong> mark each section complete as you read it.</p>
+  <WalkthroughChecklist phaseSlug={phaseSlug} steps={migrationSteps} />
+
+  <WalkthroughPhaseNav {prev} {next} {stepOf} />
+</div>
+
+<style>
+  .doc-content { max-width: var(--rm-container-narrow); }
+  .doc-meta { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-2); }
+  .doc-step { font-weight: var(--font-medium); }
+  .doc-prereqs { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-6); line-height: var(--leading-relaxed); }
+  .doc-prereqs a { color: var(--rm-primary); }
+  .doc-content h1 { font-family: var(--rm-font-display); font-size: var(--text-2xl); margin: 0 0 var(--space-4); }
+  .doc-content h3 { font-size: var(--text-lg); margin: var(--space-4) 0 var(--space-2); }
+  .doc-content p, .doc-content li { color: var(--rm-muted); line-height: var(--leading-relaxed); margin: 0 0 var(--space-4); }
+  .doc-content ol { margin: 0 0 var(--space-4); padding-left: var(--space-5); }
+  .doc-content li { margin-bottom: var(--space-2); }
+  .doc-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+  }
+  .doc-table-wide { font-size: var(--text-xs); }
+  .doc-table th, .doc-table td {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--rm-border);
+    text-align: left;
+  }
+  .doc-table th { background: var(--rm-surface-raised); font-weight: var(--font-medium); }
+  .doc-table td { color: var(--rm-muted); }
+  .build-agent-block {
+    margin: var(--space-6) 0;
+    padding: var(--space-4);
+    background: var(--rm-surface);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+  }
+  .build-agent-block h3 { margin-top: 0; }
+</style>

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/phase-0-inventory/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/phase-0-inventory/+page.svelte
@@ -1,0 +1,333 @@
+<script lang="ts">
+  /** Phase 0 — Inventory. Progressive disclosure: checklist + expandable steps. */
+  import { DASHBOARD_BASE } from "$lib/dashboard-base";
+  import { getWalkthroughPrevNext } from "$lib/docs-walkthrough-nav";
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+  import WalkthroughChecklist from "$lib/components/walkthrough/WalkthroughChecklist.svelte";
+  import WalkthroughStep from "$lib/components/walkthrough/WalkthroughStep.svelte";
+  import WalkthroughPhaseNav from "$lib/components/walkthrough/WalkthroughPhaseNav.svelte";
+
+  const { prev, next, stepOf } = getWalkthroughPrevNext("phase-0-inventory");
+  const phaseSlug = "phase-0-inventory";
+
+  const phase0Steps = [
+    { id: "0.1", label: "Identify your current routing surface" },
+    { id: "0.2", label: "Classify each piece: remove, keep, or wrap" },
+    { id: "0.3", label: "Document the current provider call pattern" },
+    { id: "0.4", label: "Plan the replacement sequence" },
+    { id: "0.5", label: "Set up a feature flag (optional)" },
+  ];
+
+  const resolveProviderSnippet = `// src/lib/server/resolve-provider.ts
+import { USE_RESTORMEL_KEYS } from '../feature-flags';
+
+export async function resolveProvider(request: AIRequest) {
+  if (USE_RESTORMEL_KEYS) {
+    return await restormelResolve(request);
+  }
+  return await legacyRouter.resolve(request);
+}`;
+
+  const inventoryExample = `REMOVE  src/lib/server/ai-router.ts        — custom fallback chain, replaced by Restormel routes
+REMOVE  src/lib/server/model-allowlist.ts   — hardcoded model list, replaced by Restormel policies
+KEEP    src/lib/server/billing/wallet.ts    — billing logic, not routing
+WRAP    src/lib/server/ingestion/worker.ts — replace ai-router call with Restormel resolve
+REMOVE  src/components/ModelPicker.svelte  — custom model UI, replaced by Restormel ModelSelector
+WRAP    src/components/KeySettings.tsx     — BYOK UI, may replace with Restormel KeyManager or keep as wrapper`;
+
+  const featureFlagSnippet = `// src/lib/feature-flags.ts
+export const USE_RESTORMEL_KEYS = process.env.USE_RESTORMEL_KEYS === 'true';`;
+
+  const flagTestSnippet = `# Confirm the flag defaults to off
+echo $USE_RESTORMEL_KEYS  # should be empty or unset
+
+# Confirm your app starts normally
+pnpm dev  # or your start command`;
+
+  const buildAgentInventoryPrompt = `You are working in [your app repo].
+
+Goal: Audit the codebase to produce a routing inventory for Restormel Keys integration.
+
+Steps:
+1. Search for all AI provider SDK imports (openai, @anthropic-ai/sdk, @google/generative-ai, or equivalent). List every file that creates a provider client or calls a completion/chat endpoint.
+2. For each file found, trace backwards: what decides which provider and model to use? List the routing/selection logic files.
+3. Search for model selection UI (dropdowns, selectors, settings pages). List those components.
+4. Search for BYOK / key management code. List those files.
+5. For each item, classify as REMOVE (Restormel replaces it), KEEP (app-specific, not routing), or WRAP (insert Restormel resolve before the existing provider call).
+6. Document the current provider call pattern for at least one primary entry point: entry point → selection logic → credential source → provider call → error handling.
+7. Write the results to docs/restormel-integration/00-routing-inventory.md (or your equivalent docs folder).
+
+DO NOT: Delete or modify any existing code. Commit real API keys or secrets. Guess about routing logic — trace the actual code paths.`;
+
+  const buildAgentFlagPrompt = `You are working in [your app repo].
+
+Goal: Add a feature flag USE_RESTORMEL_KEYS to gate the Restormel Keys integration.
+
+Steps:
+1. Create a feature flags module (e.g. src/lib/feature-flags.ts) that exports USE_RESTORMEL_KEYS, reading from process.env.USE_RESTORMEL_KEYS and defaulting to false.
+2. Identify the primary function(s) that currently resolve which AI provider to call (from the routing inventory).
+3. In each of those functions, add a conditional branch: if USE_RESTORMEL_KEYS is true, call a placeholder restormelResolve() that throws "not yet implemented"; otherwise, call the existing logic unchanged.
+4. Add USE_RESTORMEL_KEYS=false to .env.example (not .env).
+5. Verify the app starts and behaves identically with the flag unset.
+
+DO NOT: Set the flag to true yet. Modify existing routing logic beyond adding the branch. Implement restormelResolve yet. Commit real API keys or secrets.`;
+</script>
+
+<svelte:head>
+  <title>Phase 0 — Inventory your routing — Restormel Keys</title>
+  <meta name="description" content="Audit your current AI routing and classify what to remove, keep, or wrap before integrating Restormel Keys." />
+</svelte:head>
+
+<div class="doc-content">
+  <p class="doc-meta"><span class="doc-step">{stepOf}</span></p>
+  <h1>Phase 0 — Inventory your routing</h1>
+  <p class="doc-prereqs">
+    <strong>Time:</strong> ~30 minutes (audit) + implementation time varies<br />
+    <strong>Prerequisites:</strong> Access to your app's codebase, a Restormel Keys account (<a href="{DASHBOARD_BASE}/login">Sign in</a>)<br />
+    <strong>You'll need:</strong> Your app's source code, terminal access, familiarity with where your app calls AI providers today
+  </p>
+
+  <h2>Before you begin</h2>
+  <p>This walkthrough takes you from your current AI routing setup to a full Restormel Keys integration. By the end, your app uses Restormel for provider resolution, fallback routing, policy enforcement, and (optionally) embeddable UI for model selection and key management.</p>
+
+  <h3>What you'll build across all phases</h3>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Phase</th><th>What you do</th><th>What you get</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>0 — Inventory</strong></td><td>Audit and retire your custom routing</td><td>Clean separation; one place left to wire</td></tr>
+      <tr><td><strong>1 — Install</strong></td><td>Add packages, create a project in the dashboard</td><td>Working config, <code>keys doctor</code> passes</td></tr>
+      <tr><td><strong>2 — Resolve</strong></td><td>Make your first resolve call</td><td>Backend knows which provider + model to use</td></tr>
+      <tr><td><strong>3 — Routes</strong></td><td>Configure routes with fallback steps</td><td>Automatic failover when a provider is down</td></tr>
+      <tr><td><strong>4 — Policies</strong></td><td>Add allowlists, deprecation blocks, budget caps</td><td>Guardrails enforced before resolution</td></tr>
+      <tr><td><strong>5 — UI</strong></td><td>Embed ModelSelector and/or KeyManager</td><td>End-users choose models within your policy constraints</td></tr>
+      <tr><td><strong>6 — Go live</strong></td><td>Parallel run, cutover, verify</td><td>Production traffic through Restormel</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Key terms</h3>
+  <p>If these are unfamiliar, see the <a href="/keys/docs">Overview</a> or the terms below. For Phase 0:</p>
+  <ul>
+    <li><strong>Resolve</strong> — asking Restormel which provider + model + key source to use for a request.</li>
+    <li><strong>Route</strong> — a named routing configuration in the dashboard; contains steps (a fallback chain).</li>
+    <li><strong>Policy</strong> — a rule that constrains resolution (e.g. "only allow these models").</li>
+    <li><strong>Gateway Key</strong> — the <code>rk_…</code> key your backend uses to authenticate to Restormel.</li>
+  </ul>
+
+  <h3>Skip ahead</h3>
+  <p>Already done some of this?</p>
+  <ul>
+    <li>Packages installed and project created → <a href="/keys/docs/walkthrough/phase-2-resolve">Phase 2 — Resolve</a></li>
+    <li>Routes configured → <a href="/keys/docs/walkthrough/phase-4-policies">Phase 4 — Policies</a></li>
+    <li>Coming from LiteLLM, Portkey, or OpenRouter → <a href="/keys/docs/walkthrough/migration-paths">Migration paths</a></li>
+  </ul>
+
+  <h2>Why Phase 0 matters</h2>
+  <p>Most apps that need Restormel Keys already have <em>something</em> doing provider routing — even if it's a hardcoded <code>if/else</code> or a config file mapping models to providers. Phase 0 is about finding all of those pieces so you can retire them cleanly rather than running two routing systems in parallel indefinitely.</p>
+  <p>You are not deleting anything yet. You are making an inventory so the replacement in later phases is surgical.</p>
+
+  <WalkthroughStep stepId="0.1" title="Step 0.1 — Identify your current routing surface" defaultOpen={true} {phaseSlug}>
+  <p>Search your codebase for the code that currently decides which AI provider and model to use for a given request.</p>
+  <p><strong>Look for:</strong></p>
+  <ul>
+    <li>Direct provider SDK imports (<code>openai</code>, <code>@anthropic-ai/sdk</code>, <code>@google/generative-ai</code>) — where are they called, and what decides <em>which</em> one to call?</li>
+    <li>Environment variables like <code>DEFAULT_MODEL</code>, <code>AI_PROVIDER</code>, <code>OPENAI_API_KEY</code>, <code>ANTHROPIC_API_KEY</code> — who reads them and how do they affect routing?</li>
+    <li>Custom router/gateway modules — any file named <code>router</code>, <code>provider</code>, <code>gateway</code>, <code>ai-client</code>, <code>model-selector</code>, or similar.</li>
+    <li>Fallback logic — <code>try/catch</code> blocks that retry with a different provider on failure.</li>
+    <li>Model selection UI — any dropdown, radio group, or settings page where users pick a model.</li>
+    <li>BYOK settings — any UI or API where users paste their own provider API keys.</li>
+  </ul>
+  <h3>You'll see</h3>
+  <p>A list of files and modules. Organise them into three categories:</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Category</th><th>What it contains</th><th>Example</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Routing logic</strong></td><td>Code that chooses provider/model</td><td><code>src/lib/server/ai-router.ts</code>, <code>src/lib/ai/fallback.ts</code></td></tr>
+      <tr><td><strong>Model selection UI</strong></td><td>Frontend components for model/provider choice</td><td><code>src/components/ModelPicker.svelte</code>, <code>app/settings/page.tsx</code></td></tr>
+      <tr><td><strong>BYOK / key management</strong></td><td>Storage, validation, or UI for user-provided API keys</td><td><code>src/lib/server/byok.ts</code>, <code>src/components/KeySettings.tsx</code></td></tr>
+    </tbody>
+  </table>
+  <h3>How to test</h3>
+  <p>There's nothing to test yet — this is an audit. Confirm you can answer: "If I grep for every place my app decides which AI provider to call, these are the files."</p>
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — Use your IDE's "Find all references" on provider client constructors (e.g. <code>new OpenAI(...)</code>, <code>new Anthropic(...)</code>) to trace where provider choice happens. It's often faster than searching for strings.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="0.2" title="Step 0.2 — Classify each piece: remove, keep, or wrap" {phaseSlug}>
+  <p>For each item in your inventory, decide its fate:</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Decision</th><th>When to use it</th><th>Action</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Remove</strong></td><td>Custom routing logic that Restormel will replace entirely (fallback chains, provider health checks, model allowlists)</td><td>Mark for deletion in Phase 2+. Do not delete yet.</td></tr>
+      <tr><td><strong>Keep</strong></td><td>App-specific logic that Restormel does not own (billing, auth, session, orchestration/job logic, domain-specific pre/post-processing)</td><td>Leave untouched.</td></tr>
+      <tr><td><strong>Wrap</strong></td><td>Code that currently calls providers directly but should call Restormel resolve first, then call the provider with the resolved result</td><td>Refactor in Phase 2 to insert a resolve call before the provider call.</td></tr>
+    </tbody>
+  </table>
+  <h3>You'll see</h3>
+  <p>An annotated version of your inventory. For example:</p>
+  <CodeBlock language="text" code={inventoryExample} />
+  <h3>How to test</h3>
+  <p>Review your annotations with a second pair of eyes (or a coding agent). Confirm: every "REMOVE" item has a Restormel equivalent identified in the phases ahead. Every "KEEP" item genuinely has no routing responsibility.</p>
+  <div class="callout callout-pitfall">
+    <strong>Pitfall</strong> — Do not remove anything in this step. Phase 0 is audit-only. Deletion happens in Phase 2+ after the replacement is wired and tested.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="0.3" title="Step 0.3 — Document the current provider call pattern" {phaseSlug}>
+  <p>Before you change anything, record how your app currently calls AI providers. This becomes your regression baseline.</p>
+  <p>Write down (or have a coding agent extract):</p>
+  <ol>
+    <li><strong>Entry points:</strong> Which functions/routes initiate an AI provider call? (e.g. <code>POST /api/chat</code>, ingestion worker, background job)</li>
+    <li><strong>Selection logic:</strong> For each entry point, how is provider + model chosen today? (e.g. env var, user preference, hardcoded, fallback chain)</li>
+    <li><strong>Credential source:</strong> Where does the API key come from? (e.g. env var, user BYOK from database, config file)</li>
+    <li><strong>Error handling:</strong> What happens when a provider call fails? (e.g. retry same provider, fallback to different provider, return error to user)</li>
+    <li><strong>Observability:</strong> Are provider calls logged? Do you track which provider/model was used, latency, cost?</li>
+  </ol>
+  <h3>You'll see</h3>
+  <p>A short document or code comment block that captures the current state. This is your "before" snapshot.</p>
+  <h3>How to test</h3>
+  <p>Pick one entry point. Trace the request from "user action" to "provider API call" and back. Confirm your documentation matches reality.</p>
+
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: inventory-current-routing</h3>
+    <p><strong>Context docs</strong> (use in the Restormel Keys repo or adapt paths for your project): this page; <code>docs/02-architecture.md</code> §1–2.</p>
+    <p><strong>Prompt:</strong></p>
+    <CodeBlock language="text" code={buildAgentInventoryPrompt} />
+    <p><strong>Gate:</strong> A routing inventory document exists that lists every routing/selection/BYOK file, classifies each as REMOVE/KEEP/WRAP, and documents at least one end-to-end provider call pattern.</p>
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="0.4" title="Step 0.4 — Plan the replacement sequence" {phaseSlug}>
+  <p>Based on your inventory, plan which walkthrough phases address which items:</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Inventory item</th><th>Replaced by</th><th>Walkthrough phase</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Custom fallback chain</td><td>Restormel routes + steps</td><td>Phase 3</td></tr>
+      <tr><td>Hardcoded model allowlist</td><td>Restormel policies (model_allowlist)</td><td>Phase 4</td></tr>
+      <tr><td>Provider selection logic</td><td>Restormel resolve call</td><td>Phase 2</td></tr>
+      <tr><td>Model picker UI</td><td>Restormel ModelSelector component</td><td>Phase 5</td></tr>
+      <tr><td>BYOK settings UI</td><td>Restormel KeyManager component (or keep as wrapper)</td><td>Phase 5</td></tr>
+      <tr><td>Provider API key env vars</td><td>Restormel Gateway Key + provider credentials in dashboard</td><td>Phase 1</td></tr>
+    </tbody>
+  </table>
+  <h3>How to test</h3>
+  <p>Walk through each row and confirm: "When Phase N is complete, this inventory item will be retired." If any item has no corresponding phase, it either belongs in "KEEP" or you need to identify which phase handles it.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="0.5" title="Step 0.5 — Set up a feature flag (optional but recommended)" {phaseSlug}>
+  <p>If your app supports feature flags, create one now: <code>USE_RESTORMEL_KEYS</code> (or equivalent). This lets you run old and new routing in parallel during Phases 2–6 and roll back instantly if something breaks.</p>
+  <CodeBlock language="ts" code={featureFlagSnippet} />
+  <p>In your routing code, the eventual pattern will be:</p>
+  <CodeBlock language="ts" code={resolveProviderSnippet} />
+  <p>You'll wire <code>restormelResolve</code> in Phase 2. For now, the flag just exists.</p>
+  <h3>You'll see</h3>
+  <p>A feature flag that defaults to <code>false</code>. Your app behaves identically to before.</p>
+  <h3>How to test</h3>
+  <CodeBlock language="bash" code={flagTestSnippet} />
+
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: add-feature-flag</h3>
+    <p><strong>Context docs</strong> (adapt paths for your project): this page §0.5; Phase 2 (resolve); Phase 6 (go live).</p>
+    <p><strong>Prompt:</strong></p>
+    <CodeBlock language="text" code={buildAgentFlagPrompt} />
+    <p><strong>Gate:</strong> App starts with no behaviour change. A <code>USE_RESTORMEL_KEYS</code> env var exists in <code>.env.example</code>. The conditional branch is in place but the old path runs by default.</p>
+  </div>
+  </WalkthroughStep>
+
+  <p><strong>Checkpoint checklist:</strong> mark each step complete as you finish it.</p>
+  <WalkthroughChecklist phaseSlug={phaseSlug} steps={phase0Steps} />
+
+  <h2>Checkpoint</h2>
+  <p>You now have:</p>
+  <ul>
+    <li>A routing inventory listing every file that participates in AI provider selection, model choice, and BYOK.</li>
+    <li>Each item classified as REMOVE, KEEP, or WRAP.</li>
+    <li>A documented "before" snapshot of at least one provider call pattern.</li>
+    <li>A replacement mapping showing which walkthrough phase handles each inventory item.</li>
+    <li>(Optional) A feature flag ready to gate the new routing path.</li>
+  </ul>
+  <p>Nothing has been deleted or changed. Your app runs exactly as before.</p>
+
+  <WalkthroughPhaseNav {prev} {next} {stepOf} />
+</div>
+
+<style>
+  .doc-content {
+    max-width: var(--rm-container-narrow);
+  }
+  .doc-meta {
+    font-size: var(--text-sm);
+    color: var(--rm-muted);
+    margin: 0 0 var(--space-2);
+  }
+  .doc-step {
+    font-weight: var(--font-medium);
+  }
+  .doc-prereqs {
+    font-size: var(--text-sm);
+    color: var(--rm-muted);
+    margin: 0 0 var(--space-6);
+    line-height: var(--leading-relaxed);
+  }
+  .doc-prereqs a {
+    color: var(--rm-primary);
+  }
+  .doc-content h1 {
+    font-family: var(--rm-font-display);
+    font-size: var(--text-2xl);
+    margin: 0 0 var(--space-4);
+  }
+  .doc-content h2 {
+    font-size: var(--text-xl);
+    margin: var(--space-8) 0 var(--space-3);
+  }
+  .doc-content h3 {
+    font-size: var(--text-lg);
+    margin: var(--space-4) 0 var(--space-2);
+  }
+  .doc-content p, .doc-content li {
+    color: var(--rm-muted);
+    line-height: var(--leading-relaxed);
+    margin: 0 0 var(--space-4);
+  }
+  .doc-content ul, .doc-content ol {
+    margin: 0 0 var(--space-4);
+    padding-left: var(--space-5);
+  }
+  .doc-content li { margin-bottom: var(--space-2); }
+  .doc-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+  }
+  .doc-table th, .doc-table td {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--rm-border);
+    text-align: left;
+  }
+  .doc-table th {
+    background: var(--rm-surface-raised);
+    font-weight: var(--font-medium);
+  }
+  .doc-table td { color: var(--rm-muted); }
+  .doc-table code { font-family: var(--rm-font-ui); font-size: 0.9em; }
+  .build-agent-block {
+    margin: var(--space-6) 0;
+    padding: var(--space-4);
+    background: var(--rm-surface);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+  }
+  .build-agent-block h3 {
+    margin-top: 0;
+  }
+</style>

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/phase-1-install/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/phase-1-install/+page.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+  /** Phase 1 — Install and configure. Progressive disclosure: checklist + expandable steps. */
+  import { DASHBOARD_BASE } from "$lib/dashboard-base";
+  import { getWalkthroughPrevNext } from "$lib/docs-walkthrough-nav";
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+  import WalkthroughChecklist from "$lib/components/walkthrough/WalkthroughChecklist.svelte";
+  import WalkthroughStep from "$lib/components/walkthrough/WalkthroughStep.svelte";
+  import WalkthroughPhaseNav from "$lib/components/walkthrough/WalkthroughPhaseNav.svelte";
+
+  const { prev, next, stepOf } = getWalkthroughPrevNext("phase-1-install");
+  const phaseSlug = "phase-1-install";
+
+  const phase1Steps = [
+    { id: "1.1", label: "Install the packages" },
+    { id: "1.2", label: "Scaffold with the CLI" },
+    { id: "1.3", label: "Create a project in the Dashboard" },
+    { id: "1.4", label: "Generate a Gateway Key" },
+    { id: "1.5", label: "Configure provider credentials (optional)" },
+    { id: "1.6", label: "Run keys doctor again" },
+    { id: "1.7", label: "Add env var placeholders to .env.example" },
+  ];
+
+  const esmCheckCmd =
+    "node --input-type=module -e \"import { createKeys } from '@restormel/keys'; console.log('OK: createKeys is', typeof createKeys)\"";
+
+  const confirmPackageCmd =
+    "# Confirm the package installed correctly\nnode -e \"const k = require('@restormel/keys'); console.log('OK:', Object.keys(k).length, 'exports')\"";
+
+  const doctorTestCmd = 'npx @restormel/keys-cli doctor && echo "PASS" || echo "FAIL"';
+</script>
+
+<svelte:head>
+  <title>Phase 1 — Install and configure — Restormel Keys</title>
+  <meta name="description" content="Install Restormel Keys packages, create a project in the dashboard, generate a Gateway Key, run keys doctor." />
+</svelte:head>
+
+<div class="doc-content">
+  <p class="doc-meta"><span class="doc-step">{stepOf}</span></p>
+  <h1>Phase 1 — Install and configure</h1>
+  <p class="doc-prereqs">
+    <strong>Time:</strong> ~15 minutes<br />
+    <strong>Prerequisites:</strong> <a href="/keys/docs/walkthrough/phase-0-inventory">Phase 0</a> complete (routing inventory exists), a Restormel Keys account<br />
+    <strong>You'll need:</strong> Terminal access, your app's package manager (pnpm, npm, or yarn), access to the <a href={DASHBOARD_BASE}>Dashboard</a>
+  </p>
+
+  <p>This phase gets the Restormel Keys packages into your project and creates the dashboard-side resources (workspace, project, environment, Gateway Key) that later phases depend on. By the end, <code>keys doctor</code> passes (framework, packages, and local config) and your dashboard shows a project ready for routes and policies. The CLI does not validate Cloud env vars (e.g. <code>RESTORMEL_GATEWAY_KEY</code>, <code>RESTORMEL_PROJECT_ID</code>) today — you verify those in Phase 2 when you make your first resolve call.</p>
+
+  <WalkthroughStep stepId="1.1" title="Step 1.1 — Install the packages" defaultOpen={true} {phaseSlug}>
+  <p>Choose the packages for your framework. The headless core (<code>@restormel/keys</code>) is always required. Add UI packages if you plan to embed ModelSelector or KeyManager (Phase 5).</p>
+  <p><strong>Next.js / React:</strong></p>
+  <CodeBlock language="bash" code="pnpm add @restormel/keys @restormel/keys-react @restormel/keys-elements" />
+  <p><strong>SvelteKit:</strong></p>
+  <CodeBlock language="bash" code="pnpm add @restormel/keys @restormel/keys-svelte" />
+  <p><strong>Vanilla / Astro / Web Components:</strong></p>
+  <CodeBlock language="bash" code="pnpm add @restormel/keys @restormel/keys-elements" />
+  <p><strong>Server-only (no UI, just resolve):</strong></p>
+  <CodeBlock language="bash" code="pnpm add @restormel/keys" />
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — Not sure which packages you need? See <a href="/keys/docs/compatibility">Framework compatibility</a> for the full decision tree. If you only need server-side resolution and no embedded UI, the headless core is enough.
+  </div>
+  <h3>You'll see</h3>
+  <p>The packages appear in your <code>package.json</code> dependencies. No build errors.</p>
+  <h3>How to test</h3>
+  <CodeBlock language="bash" code={confirmPackageCmd} />
+  <p>If you use ESM (<code>"type": "module"</code> in your <code>package.json</code>):</p>
+  <CodeBlock language="bash" code={esmCheckCmd} />
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="1.2" title="Step 1.2 — Scaffold with the CLI" {phaseSlug}>
+  <p>The CLI generates a starter config and validates your setup. If you prefer to configure manually, skip to Step 1.3.</p>
+  <CodeBlock language="bash" code="npx @restormel/keys-cli init" />
+  <p>The <code>init</code> command detects your framework, suggests the right packages (confirming what you installed in 1.1), and creates a <code>restormel.config.json</code> in your project root.</p>
+  <h3>You'll see</h3>
+  <p>Interactive prompts asking for your framework, which providers you use, and your preferred storage adapter. On completion:</p>
+  <CodeBlock language="text" code={`✔ Detected framework: Next.js (App Router)
+✔ Created restormel.config.json
+✔ Suggested packages: @restormel/keys, @restormel/keys-react, @restormel/keys-elements
+
+Run 'keys doctor' to verify your setup.`} />
+  <h3>How to test</h3>
+  <CodeBlock language="bash" code="npx @restormel/keys-cli doctor" />
+  <p><code>doctor</code> checks framework detection, package versions, config validity, and key health. At this point it should pass with a note that no Gateway Key is configured yet (that's Step 1.4).</p>
+  <div class="callout callout-note">
+    <strong>If you see "framework not detected"</strong> — The CLI looks for framework markers (<code>next.config.*</code>, <code>svelte.config.*</code>, <code>astro.config.*</code>). If your project uses a non-standard layout, run <code>keys init --framework next</code> (or <code>sveltekit</code>, <code>react</code>, <code>astro</code>) to specify manually.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="1.3" title="Step 1.3 — Create a project in the Dashboard" {phaseSlug}>
+  <p>Open the <a href={DASHBOARD_BASE}>Dashboard</a> and sign in with GitHub.</p>
+  <ol>
+    <li><strong>Create a workspace</strong> (if you don't have one). This is your top-level organisational container. Name it after your company or team.</li>
+    <li><strong>Create a project.</strong> Name it after your app (e.g. "My Writing Tool"). The project is where routes, policies, and keys live.</li>
+    <li><strong>Create an environment</strong> within the project: <code>production</code>. You can add <code>staging</code> later. The environment scopes routes and policies to a deployment context.</li>
+  </ol>
+  <div class="callout callout-note">
+    <strong>Dashboard</strong> — Workspace → Projects → <strong>Create project</strong> → name it → <strong>Environments</strong> → <strong>Create environment</strong> → name it <code>production</code>.
+  </div>
+  <h3>You'll see</h3>
+  <p>The project detail page in the dashboard with: project name and ID; an "Environments" section showing <code>production</code>; empty "Routes" and "Policies" sections (you'll fill these in Phases 3–4); an "API Keys" section (you'll generate a Gateway Key next).</p>
+  <h3>How to test</h3>
+  <p>The project detail page loads without errors. The environment <code>production</code> is listed.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="1.4" title="Step 1.4 — Generate a Gateway Key" {phaseSlug}>
+  <p>Still in the Dashboard, on your project detail page:</p>
+  <ol>
+    <li>Click <strong>Generate API key</strong> (or navigate to the API Keys section).</li>
+    <li>Copy the full key immediately. It has the format <code>rk_…</code> and is shown only once.</li>
+    <li>Store it securely. This is your <strong>Gateway Key</strong> — the credential your backend uses to authenticate to the Restormel resolve API.</li>
+  </ol>
+  <div class="callout callout-security">
+    <strong>Security</strong> — The Gateway Key is a secret. Store it in your environment variables or secret manager. Never commit it to your repo, paste it into a coding agent, or log it in application output.
+  </div>
+  <h3>You'll see</h3>
+  <p>A key displayed once with a "Copy" button. After you navigate away, you see only the key prefix (e.g. <code>rk_a3f…</code>) in the dashboard — the full key is not retrievable.</p>
+  <h3>How to test</h3>
+  <p>You test the key works in Phase 2 when you make your first resolve call. For now, confirm it's stored:</p>
+  <CodeBlock language="bash" code={`# Add to your .env (gitignored) — NOT .env.example
+# RESTORMEL_GATEWAY_KEY=rk_your_key_here
+# RESTORMEL_PROJECT_ID=your_project_id_here
+# RESTORMEL_ENVIRONMENT_ID=production`} />
+  <p>Update <code>.env.example</code> with placeholder names (no values):</p>
+  <CodeBlock language="bash" code={`# .env.example
+RESTORMEL_GATEWAY_KEY=
+RESTORMEL_PROJECT_ID=
+RESTORMEL_ENVIRONMENT_ID=`} />
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="1.5" title="Step 1.5 — Configure provider credentials (optional)" {phaseSlug}>
+  <p>If your app uses <strong>platform keys</strong> (your own OpenAI/Anthropic/Google keys, not user-provided BYOK), you can add them as provider credentials in the dashboard now. This is optional — you can also continue using your existing env vars and let Restormel resolve point to the provider while you supply the key yourself.</p>
+  <p>To add provider credentials in the dashboard: in your project, go to <strong>Provider Credentials</strong>; click <strong>Add credential</strong>, choose the provider (e.g. OpenAI), paste your API key; Restormel validates the key and stores it encrypted.</p>
+  <p>If you prefer to keep provider keys in your own env vars and only use Restormel for routing decisions, skip this step. The resolve response tells you <em>which</em> provider to call; you can supply the key from your own env.</p>
+  <h3>You'll see</h3>
+  <p>The credential listed in the dashboard with the provider name and a masked key preview. Validation status shows green if the key is valid.</p>
+  <h3>How to test</h3>
+  <p>No code-level test yet. The dashboard shows the credential as valid.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="1.6" title="Step 1.6 — Run keys doctor again" {phaseSlug}>
+  <p>Now that you have a config (and optionally env vars), run the doctor check again:</p>
+  <CodeBlock language="bash" code="npx @restormel/keys-cli doctor" />
+  <h3>You'll see</h3>
+  <p><code>keys doctor</code> checks framework detection, package versions, and config validity. Example output:</p>
+  <CodeBlock language="text" code={`✔ Framework: Next.js (App Router)
+✔ Packages: @restormel/keys@0.2.0, @restormel/keys-react@0.1.0, @restormel/keys-elements@0.1.0
+✔ Config: restormel.config.json valid
+
+All checks passed.`} />
+  <p>Cloud env vars (<code>RESTORMEL_GATEWAY_KEY</code>, <code>RESTORMEL_PROJECT_ID</code>, <code>RESTORMEL_ENVIRONMENT_ID</code>) are not validated by the CLI. You confirm they work in Phase 2 when you call the resolve endpoint.</p>
+  <h3>How to test</h3>
+  <CodeBlock language="bash" code={doctorTestCmd} />
+  <div class="callout callout-pitfall">
+    <strong>Pitfall</strong> — If <code>doctor</code> reports missing packages, install them (Step 1.1). If it reports a missing config, run <code>keys init</code> (Step 1.2). For resolve to work in Phase 2, ensure your <code>.env</code> (or secret manager) has the Gateway Key and project/environment IDs and that your app loads them at runtime.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="1.7" title="Step 1.7 — Add env var placeholders to .env.example" {phaseSlug}>
+  <p>Make sure your repo's <code>.env.example</code> documents the new variables so collaborators know what to set:</p>
+  <CodeBlock language="bash" code={`# .env.example — Restormel Keys integration
+RESTORMEL_GATEWAY_KEY=
+RESTORMEL_PROJECT_ID=
+RESTORMEL_ENVIRONMENT_ID=
+# Optional: feature flag for phased rollout (see Phase 0)
+USE_RESTORMEL_KEYS=false`} />
+  </WalkthroughStep>
+
+  <p><strong>Checkpoint checklist:</strong> mark each step complete as you finish it.</p>
+  <WalkthroughChecklist phaseSlug={phaseSlug} steps={phase1Steps} />
+
+  <h2>Checkpoint</h2>
+  <p>You now have:</p>
+  <ul>
+    <li>Restormel Keys packages installed in your project.</li>
+    <li>A <code>restormel.config.json</code> that matches your framework.</li>
+    <li>A project and environment created in the Restormel Dashboard.</li>
+    <li>A Gateway Key stored in your <code>.env</code> (gitignored).</li>
+    <li><code>keys doctor</code> passing.</li>
+  </ul>
+  <p>Your app still runs on the old routing path (the feature flag from Phase 0 is still <code>false</code>). Nothing has changed in your application behaviour.</p>
+
+  <WalkthroughPhaseNav {prev} {next} {stepOf} />
+</div>
+
+<style>
+  .doc-content {
+    max-width: var(--rm-container-narrow);
+  }
+  .doc-meta { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-2); }
+  .doc-step { font-weight: var(--font-medium); }
+  .doc-prereqs { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-6); line-height: var(--leading-relaxed); }
+  .doc-prereqs a { color: var(--rm-primary); }
+  .doc-content h1 { font-family: var(--rm-font-display); font-size: var(--text-2xl); margin: 0 0 var(--space-4); }
+  .doc-content h2 { font-size: var(--text-xl); margin: var(--space-8) 0 var(--space-3); }
+  .doc-content h3 { font-size: var(--text-lg); margin: var(--space-4) 0 var(--space-2); }
+  .doc-content p, .doc-content li { color: var(--rm-muted); line-height: var(--leading-relaxed); margin: 0 0 var(--space-4); }
+  .doc-content ul, .doc-content ol { margin: 0 0 var(--space-4); padding-left: var(--space-5); }
+  .doc-content li { margin-bottom: var(--space-2); }
+</style>

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/phase-2-resolve/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/phase-2-resolve/+page.svelte
@@ -1,0 +1,289 @@
+<script lang="ts">
+  /** Phase 2 — Resolve. Progressive disclosure: checklist + expandable steps. */
+  import { DASHBOARD_BASE } from "$lib/dashboard-base";
+  import { getWalkthroughPrevNext } from "$lib/docs-walkthrough-nav";
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+  import WalkthroughChecklist from "$lib/components/walkthrough/WalkthroughChecklist.svelte";
+  import WalkthroughStep from "$lib/components/walkthrough/WalkthroughStep.svelte";
+  import WalkthroughPhaseNav from "$lib/components/walkthrough/WalkthroughPhaseNav.svelte";
+
+  const { prev, next, stepOf } = getWalkthroughPrevNext("phase-2-resolve");
+  const phaseSlug = "phase-2-resolve";
+
+  const phase2Steps = [
+    { id: "2.1", label: "Understand the resolve flow" },
+    { id: "2.2", label: "Test resolve with curl" },
+    { id: "2.3", label: "Create a typed resolve client" },
+    { id: "2.4", label: "Wire resolve into the feature flag" },
+    { id: "2.5", label: "Add error handling and local fallback" },
+    { id: "2.6", label: "(Optional) Use the npm package resolve locally" },
+  ];
+
+  const curlResolve = `curl -X POST \\
+  "https://restormel.dev/keys/dashboard/api/projects/\${RESTORMEL_PROJECT_ID}/resolve" \\
+  -H "Authorization: Bearer \${RESTORMEL_GATEWAY_KEY}" \\
+  -H "Content-Type: application/json" \\
+  -d '{ "environmentId": "production" }'`;
+
+  const resolveResponseExample = `{
+  "data": {
+    "routeId": "route_123",
+    "providerType": "openai",
+    "modelId": "gpt-4o",
+    "explanation": "route=route_123 step=0 provider=openai model=gpt-4o"
+  }
+}`;
+
+  const typedResolveClientExample = `// src/lib/server/restormel.ts
+interface ResolveRequest { environmentId: string; routeId?: string; }
+interface ResolveResponse {
+  data: { routeId: string; providerType: string | null; modelId: string | null; explanation: string; };
+}
+const RESTORMEL_BASE_URL = process.env.RESTORMEL_BASE_URL ?? 'https://restormel.dev/keys/dashboard';
+const RESTORMEL_GATEWAY_KEY = process.env.RESTORMEL_GATEWAY_KEY ?? '';
+const RESTORMEL_PROJECT_ID = process.env.RESTORMEL_PROJECT_ID ?? '';
+
+export async function restormelResolve(request: ResolveRequest): Promise<ResolveResponse> {
+  const url = \`\${RESTORMEL_BASE_URL}/api/projects/\${RESTORMEL_PROJECT_ID}/resolve\`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Authorization': \`Bearer \${RESTORMEL_GATEWAY_KEY}\`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(\`Restormel resolve failed (\${res.status}): \${body.slice(0, 200)}\`);
+  }
+  return res.json() as Promise<ResolveResponse>;
+}`;
+
+  const resolveClientTabs = [
+    { label: "TypeScript", language: "ts", code: typedResolveClientExample },
+    {
+      label: "JavaScript",
+      language: "js",
+      code: `// src/lib/server/restormel.js
+const RESTORMEL_BASE_URL = process.env.RESTORMEL_BASE_URL ?? 'https://restormel.dev/keys/dashboard';
+const RESTORMEL_GATEWAY_KEY = process.env.RESTORMEL_GATEWAY_KEY ?? '';
+const RESTORMEL_PROJECT_ID = process.env.RESTORMEL_PROJECT_ID ?? '';
+
+export async function restormelResolve(request) {
+  const url = \`\${RESTORMEL_BASE_URL}/api/projects/\${RESTORMEL_PROJECT_ID}/resolve\`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Authorization': \`Bearer \${RESTORMEL_GATEWAY_KEY}\`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(\`Restormel resolve failed (\${res.status}): \${body.slice(0, 200)}\`);
+  }
+  return res.json();
+}`,
+    },
+  ];
+
+  const sveltekitImportExample = "import { restormelResolve } from '$lib/server/restormel';";
+
+  const testResolveScriptExample = `// scripts/test-resolve.ts (run with tsx or ts-node)
+import { restormelResolve } from '../src/lib/server/restormel';
+const result = await restormelResolve({ environmentId: 'production' });
+console.log('Resolved:', JSON.stringify(result, null, 2));`;
+
+  const resolveProviderWiringExample = `// src/lib/server/resolve-provider.ts
+import { USE_RESTORMEL_KEYS } from '../feature-flags';
+import { restormelResolve } from './restormel';
+
+export async function resolveProvider(preferredModel?: string) {
+  if (USE_RESTORMEL_KEYS) {
+    const result = await restormelResolve({
+      environmentId: process.env.RESTORMEL_ENVIRONMENT_ID ?? 'production',
+    });
+    return {
+      provider: result.data.providerType ?? process.env.DEFAULT_AI_PROVIDER ?? 'openai',
+      model: result.data.modelId ?? preferredModel ?? null,
+      source: 'restormel',
+    };
+  }
+  return legacyResolve(preferredModel);
+}`;
+
+  const resolveErrorHandlingExample = `if (USE_RESTORMEL_KEYS) {
+  try {
+    const result = await restormelResolve({ environmentId: process.env.RESTORMEL_ENVIRONMENT_ID ?? 'production' });
+    return {
+      provider: result.data.providerType ?? process.env.DEFAULT_AI_PROVIDER ?? 'openai',
+      model: result.data.modelId ?? preferredModel ?? null,
+      source: 'restormel',
+    };
+  } catch (err) {
+    console.error('[restormel] Resolve failed, falling back to legacy:', err);
+  }
+}
+return legacyResolve(preferredModel);`;
+</script>
+
+<svelte:head>
+  <title>Phase 2 — Resolve your first model — Restormel Keys</title>
+  <meta name="description" content="Wire a resolve call into your backend; verify providerType and modelId; add error handling and feature-flag branch." />
+</svelte:head>
+
+<div class="doc-content">
+  <p class="doc-meta"><span class="doc-step">{stepOf}</span></p>
+  <h1>Phase 2 — Resolve your first model</h1>
+  <p class="doc-prereqs">
+    <strong>Time:</strong> ~15 minutes<br />
+    <strong>Prerequisites:</strong> <a href="/keys/docs/walkthrough/phase-1-install">Phase 1</a> complete (packages installed, project created, Gateway Key in <code>.env</code>, <code>keys doctor</code> passes)<br />
+    <strong>You'll need:</strong> Terminal access, a running dev server (or curl/httpie), your Gateway Key and Project ID from the <a href={DASHBOARD_BASE}>Dashboard</a>
+  </p>
+
+  <p>This phase wires a single resolve call into your backend. By the end, your app can ask Restormel "which provider and model should I use for this request?" and get a concrete answer. You verify the response shape, then plug it into the feature-flag branch from Phase 0.</p>
+
+  <WalkthroughStep stepId="2.1" title="Step 2.1 — Understand the resolve flow" defaultOpen={true} {phaseSlug}>
+  <p>Before writing code, understand what happens when your backend calls resolve:</p>
+  <ol>
+    <li>Your backend sends a <code>POST</code> to the resolve endpoint with your project ID and environment.</li>
+    <li>Restormel evaluates the project's routes (fallback chain) and policies (allowlists, budgets, etc.).</li>
+    <li>Restormel returns a JSON object telling you which provider, model, and key source to use.</li>
+    <li>Your backend calls the AI provider directly using that information.</li>
+  </ol>
+  <p>Restormel does <strong>not</strong> proxy the AI request. It tells you <em>where</em> to send it; you send it yourself. This keeps latency low and means your provider API keys never transit through Restormel (unless you've stored provider credentials in the dashboard and want Restormel to supply them).</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="2.2" title="Step 2.2 — Test resolve with curl" {phaseSlug}>
+  <p>Before writing any application code, confirm the resolve endpoint works with a raw HTTP call. This isolates Restormel from your app so you can verify the plumbing.</p>
+  <CodeBlock language="bash" code={curlResolve} />
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — If you use the Cloud API through the Zuplo gateway, the URL is your gateway URL and you authenticate with your consumer key (<code>zpka_…</code>). For this walkthrough we use the dashboard API directly with the Gateway Key. See <a href="/keys/docs/cloud-api">Cloud API</a> for the gateway path.
+  </div>
+  <h3>You'll see</h3>
+  <p>A JSON response wrapped under <code>data</code>:</p>
+  <CodeBlock language="json" code={resolveResponseExample} />
+  <p><strong>Reading the response:</strong></p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Field</th><th>Meaning</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><code>data.routeId</code></td><td>The matched route ID (created in the dashboard in Phase 3)</td></tr>
+      <tr><td><code>data.providerType</code></td><td>The AI provider to call (e.g. <code>openai</code>, <code>anthropic</code>, <code>google</code>)</td></tr>
+      <tr><td><code>data.modelId</code></td><td>The model to use; may be <code>null</code> if none configured</td></tr>
+      <tr><td><code>data.explanation</code></td><td>A human-readable trace of the resolution path (useful for debugging)</td></tr>
+    </tbody>
+  </table>
+  <p>If you have not created a route for this <code>environmentId</code> yet, resolve returns <strong>404</strong> with <code>{'{'} "error": "no_route" {'}'}</code>. That is expected — you create your first route in Phase 3.</p>
+  <h3>How to test</h3>
+  <p>The curl command returns HTTP 200 and a JSON body with <code>data.providerType</code>. If you get:</p>
+  <ul>
+    <li><strong>401 Unauthorized</strong> — your Gateway Key is wrong or missing. Check <code>RESTORMEL_GATEWAY_KEY</code>.</li>
+    <li><strong>404 Not Found</strong> — your project ID is wrong. Check <code>RESTORMEL_PROJECT_ID</code> against the dashboard.</li>
+    <li><strong>404 no_route</strong> — your project has no active route for the <code>environmentId</code> you sent. Create a route in Phase 3.</li>
+  </ul>
+  <div class="callout callout-note">
+    <strong>If you see "no_key_available"</strong> — Your route's steps point at providers that are not currently usable. Create a route with at least one enabled step (Phase 3). If you only want Restormel to choose a route while you supply provider credentials in your own app, use local resolve (Step 2.6) instead of the dashboard resolve endpoint.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="2.3" title="Step 2.3 — Create a typed resolve client" {phaseSlug}>
+  <p>Add a small server-side module that calls the resolve endpoint. This becomes the single place your app asks Restormel for routing decisions.</p>
+  <p><strong>Next.js / generic Node (TypeScript):</strong></p>
+  <CodeBlock tabs={resolveClientTabs} />
+  <p><strong>SvelteKit:</strong> Same implementation — SvelteKit server modules use the same Node/fetch APIs. Import with <code>{sveltekitImportExample}</code></p>
+  <h3>You'll see</h3>
+  <p>A new file at <code>src/lib/server/restormel.ts</code> (or equivalent). No UI or behaviour changes yet.</p>
+  <h3>How to test</h3>
+  <CodeBlock language="ts" code={testResolveScriptExample} />
+  <CodeBlock language="bash" code={`npx tsx scripts/test-resolve.ts`} />
+  <p>You should see the same JSON structure as the curl response from Step 2.2.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="2.4" title="Step 2.4 — Wire resolve into the feature flag" {phaseSlug}>
+  <p>Connect the resolve client to the feature-flag branch you created in Phase 0 (Step 0.5). This is the moment your app can optionally route through Restormel — but still defaults to the old path.</p>
+  <CodeBlock language="ts" code={resolveProviderWiringExample} />
+  <h3>You'll see</h3>
+  <p>Your existing routing code still runs (the flag is <code>false</code>). The new path exists but is not active.</p>
+  <h3>How to test</h3>
+  <p><strong>Legacy path (flag off):</strong> <code>pnpm dev</code> — make a request that triggers an AI call; it should behave identically to before.</p>
+  <p><strong>Restormel path (flag on):</strong> <code>USE_RESTORMEL_KEYS=true pnpm dev</code> — make the same request; it should now resolve via Restormel. Turn the flag back off after testing. Production cutover happens in Phase 6.</p>
+  <div class="callout callout-pitfall">
+    <strong>Pitfall</strong> — If the Restormel path returns <code>no_key_available</code> and your app crashes, add error handling: catch the resolve error and fall back to the legacy path. This is your safety net during the parallel-run period.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="2.5" title="Step 2.5 — Add error handling and local fallback" {phaseSlug}>
+  <p>The resolve call is a network request. It can fail (network error, Restormel downtime, misconfiguration). Your app should handle this gracefully.</p>
+  <CodeBlock language="ts" code={resolveErrorHandlingExample} />
+  <h3>You'll see</h3>
+  <p>If Restormel is unreachable or returns an error, your app logs the error and continues with the legacy routing path. No user-facing impact.</p>
+  <h3>How to test</h3>
+  <p>Temporarily set an invalid Gateway Key and enable the flag: <code>RESTORMEL_GATEWAY_KEY=rk_invalid USE_RESTORMEL_KEYS=true pnpm dev</code>. Make a request that triggers an AI call. You should see a console error and the request should succeed via the legacy path. Restore your real Gateway Key after testing.</p>
+
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: create-resolve-client</h3>
+    <p><strong>Context docs</strong> (adapt paths for your project): this page; Phase 0 (routing inventory, feature flag).</p>
+    <p><strong>Goal:</strong> Create a typed Restormel resolve client, wire it into the feature flag from Phase 0, and add error handling with legacy fallback. Use <code>ResolveResponse.data.providerType</code> and <code>data.modelId</code>. Add <code>RESTORMEL_BASE_URL</code> to <code>.env.example</code>. Create <code>scripts/test-resolve.ts</code>. Verify flag off → unchanged; flag on → Restormel or fallback.</p>
+    <p><strong>DO NOT:</strong> Set <code>USE_RESTORMEL_KEYS=true</code> as default. Log the Gateway Key or raw keys. Modify legacy logic. Commit real API keys or secrets.</p>
+    <p><strong>Gate:</strong> Test script prints a valid resolve response with <code>data.providerType</code>. Flag off → unchanged behaviour. Flag on + invalid key → fallback to legacy and log error. No secrets committed.</p>
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="2.6" title="Step 2.6 — (Optional) Use the npm package resolve locally" {phaseSlug}>
+  <p>If your backend is Node/TypeScript and you prefer to resolve locally (no HTTP call to the dashboard), you can use <code>@restormel/keys</code> in-process. This uses the same routing engine but runs locally. Useful if you want zero added latency, manage provider keys in your own env vars, and don't need dashboard-configured routes yet.</p>
+  <p>See the full code sample in the repo at <code>docs/walkthrough/04-phase-2-resolve.md</code> (Step 2.6). You get the same resolution shape but resolved locally.</p>
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — You can start with local resolve (this step) and switch to HTTP resolve (Step 2.3) later when you're ready to use dashboard-managed routes and policies. The <code>resolveProvider</code> wrapper from Step 2.4 makes this a one-line change.
+  </div>
+  </WalkthroughStep>
+
+  <p><strong>Checkpoint checklist:</strong> mark each step complete as you finish it.</p>
+  <WalkthroughChecklist phaseSlug={phaseSlug} steps={phase2Steps} />
+
+  <h2>Checkpoint</h2>
+  <p>You now have:</p>
+  <ul>
+    <li>A typed resolve client that calls the Restormel API (<code>src/lib/server/restormel.ts</code>).</li>
+    <li>(Optional) A local resolve instance using <code>@restormel/keys</code>.</li>
+    <li>A <code>resolveProvider</code> function that branches on the feature flag: Restormel path (with error fallback) or legacy path.</li>
+    <li>A test script that confirms the resolve endpoint works.</li>
+    <li>Error handling that falls back to legacy routing if Restormel is unreachable.</li>
+  </ul>
+  <p>Your app still defaults to the legacy routing path. You've confirmed the Restormel path works when the flag is on.</p>
+
+  <WalkthroughPhaseNav {prev} {next} {stepOf} />
+</div>
+
+<style>
+  .doc-content { max-width: var(--rm-container-narrow); }
+  .doc-meta { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-2); }
+  .doc-step { font-weight: var(--font-medium); }
+  .doc-prereqs { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-6); line-height: var(--leading-relaxed); }
+  .doc-prereqs a { color: var(--rm-primary); }
+  .doc-content h1 { font-family: var(--rm-font-display); font-size: var(--text-2xl); margin: 0 0 var(--space-4); }
+  .doc-content h2 { font-size: var(--text-xl); margin: var(--space-8) 0 var(--space-3); }
+  .doc-content h3 { font-size: var(--text-lg); margin: var(--space-4) 0 var(--space-2); }
+  .doc-content p, .doc-content li { color: var(--rm-muted); line-height: var(--leading-relaxed); margin: 0 0 var(--space-4); }
+  .doc-content ul, .doc-content ol { margin: 0 0 var(--space-4); padding-left: var(--space-5); }
+  .doc-content li { margin-bottom: var(--space-2); }
+  .doc-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+  }
+  .doc-table th, .doc-table td {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--rm-border);
+    text-align: left;
+  }
+  .doc-table th { background: var(--rm-surface-raised); font-weight: var(--font-medium); }
+  .doc-table td { color: var(--rm-muted); }
+  .doc-table code { font-family: var(--rm-font-ui); font-size: 0.9em; }
+  .build-agent-block {
+    margin: var(--space-6) 0;
+    padding: var(--space-4);
+    background: var(--rm-surface);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+  }
+  .build-agent-block h3 { margin-top: 0; }
+</style>

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/phase-3-routes/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/phase-3-routes/+page.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+  /** Phase 3 — Routes. Progressive disclosure: checklist + expandable steps. */
+  import { DASHBOARD_BASE } from "$lib/dashboard-base";
+  import { getWalkthroughPrevNext } from "$lib/docs-walkthrough-nav";
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+  import WalkthroughChecklist from "$lib/components/walkthrough/WalkthroughChecklist.svelte";
+  import WalkthroughStep from "$lib/components/walkthrough/WalkthroughStep.svelte";
+  import WalkthroughPhaseNav from "$lib/components/walkthrough/WalkthroughPhaseNav.svelte";
+
+  const { prev, next, stepOf } = getWalkthroughPrevNext("phase-3-routes");
+  const phaseSlug = "phase-3-routes";
+
+  const phase3Steps = [
+    { id: "3.1", label: "Understand routes and steps" },
+    { id: "3.2", label: "Create your first route in the Dashboard" },
+    { id: "3.3", label: "Resolve with the route ID" },
+    { id: "3.4", label: "Test fallback behaviour" },
+    { id: "3.5", label: "Wire route IDs into your application" },
+    { id: "3.6", label: "(Optional) Create a second route" },
+  ];
+
+  const curlRoute = `curl -X POST \\
+  "https://restormel.dev/keys/dashboard/api/projects/\${RESTORMEL_PROJECT_ID}/resolve" \\
+  -H "Authorization: Bearer \${RESTORMEL_GATEWAY_KEY}" \\
+  -H "Content-Type: application/json" \\
+  -d '{ "environmentId": "production", "routeId": "ingestion" }'`;
+
+  const curlJq = `curl -s -X POST "..." -d '{ "environmentId": "production", "routeId": "ingestion" }' | jq '.data.providerType, .data.modelId'`;
+
+  const resolveClientSnippet = `const result = await restormelResolve({
+  environmentId: process.env.RESTORMEL_ENVIRONMENT_ID ?? 'production',
+  routeId: 'ingestion',
+});`;
+
+  const stepsApiBodyExample = `{ "orderIndex": 0, "providerPreference": "openai", "modelId": "gpt-4o", "fallbackOn": "error", "enabled": true }`;
+
+  const routeDiagram = `Route: "ingestion"
+Mode:  fallback_chain
+
+  Step 1 → OpenAI   (gpt-4o)           → try first
+  Step 2 → Anthropic (claude-sonnet)  → if step 1 fails
+  Step 3 → Google    (gemini-2.5-pro) → if step 2 fails`;
+
+  const callSiteIngestion = "resolveProvider({ routeId: 'ingestion' })";
+  const callSiteChat = "resolveProvider({ routeId: 'interactive', model: userSelectedModel })";
+  const optionsSignature = "options?: { routeId?: string; model?: string }";
+
+  const resolveProviderWithRouteIdExample = `export async function resolveProvider(options?: { routeId?: string; model?: string }) {
+  if (USE_RESTORMEL_KEYS) {
+    try {
+      const result = await restormelResolve({
+        environmentId: process.env.RESTORMEL_ENVIRONMENT_ID ?? 'production',
+        routeId: options?.routeId,
+      });
+      return {
+        provider: result.data.providerType ?? process.env.DEFAULT_AI_PROVIDER ?? 'openai',
+        model: result.data.modelId ?? options?.model ?? null,
+        source: 'restormel',
+      };
+    } catch (err) {
+      console.error('[restormel] Resolve failed, falling back to legacy:', err);
+    }
+  }
+  return legacyResolve(options?.model);
+}`;
+</script>
+
+<svelte:head>
+  <title>Phase 3 — Add routes and fallbacks — Restormel Keys</title>
+  <meta name="description" content="Create routes with steps in the Dashboard; configure fallback chain; wire route IDs into your resolve client." />
+</svelte:head>
+
+<div class="doc-content">
+  <p class="doc-meta"><span class="doc-step">{stepOf}</span></p>
+  <h1>Phase 3 — Add routes and fallbacks</h1>
+  <p class="doc-prereqs">
+    <strong>Time:</strong> ~20 minutes<br />
+    <strong>Prerequisites:</strong> <a href="/keys/docs/walkthrough/phase-2-resolve">Phase 2</a> complete (resolve client works, feature flag wired)<br />
+    <strong>You'll need:</strong> Access to the <a href={DASHBOARD_BASE}>Dashboard</a>, your project and environment from Phase 1
+  </p>
+
+  <p>This phase moves your routing decisions from "Restormel picks the default provider" to "Restormel evaluates a named route with multiple steps and fails over automatically." By the end, you have a fallback chain configured in the dashboard, and your resolve call returns results shaped by that chain.</p>
+
+  <WalkthroughStep stepId="3.1" title="Step 3.1 — Understand routes and steps" defaultOpen={true} {phaseSlug}>
+  <p>A <strong>route</strong> is a named routing configuration inside your project. It contains one or more <strong>steps</strong>, evaluated in order. Each step specifies a provider preference and an optional model. The <strong>route mode</strong> controls how steps are evaluated.</p>
+  <CodeBlock language="text" code={routeDiagram} />
+  <p>When your backend calls resolve with <code>routeId: "ingestion"</code>, Restormel walks the chain. If the first step's provider has a valid key and is not blocked by a policy, it's returned. If not (no key, rate-limited, deprecated), Restormel tries the next step.</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Mode</th><th>Behaviour</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><code>fallback_chain</code></td><td>Try steps in order; return the first that resolves successfully</td></tr>
+      <tr><td><code>user_preferred</code></td><td>Use the user's preferred provider if a BYOK key exists, then fall back to the chain</td></tr>
+    </tbody>
+  </table>
+  <p>You can create multiple routes per project — for example, <code>ingestion</code> for background jobs and <code>interactive</code> for user-facing requests with different fallback priorities.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="3.2" title="Step 3.2 — Create your first route in the Dashboard" {phaseSlug}>
+  <div class="callout callout-note">
+    <strong>Dashboard</strong> — Your project → <strong>Routes</strong> → <strong>Create route</strong>.
+  </div>
+  <ol>
+    <li><strong>Name:</strong> Give the route a descriptive name (e.g. <code>ingestion</code>, <code>chat</code>, <code>interactive</code>). This becomes the <code>routeId</code> you pass to resolve.</li>
+    <li><strong>Route mode:</strong> Select <code>fallback_chain</code>.</li>
+    <li><strong>Save</strong> the route.</li>
+  </ol>
+  <p>At the moment, the dashboard UI shows steps but you create steps via the Steps API in Step 3.4a. Adjust provider order and models to match your actual preferences.</p>
+  <h3>You'll see</h3>
+  <p>The route detail page in the dashboard showing your named route, mode, and the steps in order. Each step shows the provider, model, and fallback condition.</p>
+  <h3>How to test</h3>
+  <p>No code change yet. Confirm the route appears in the dashboard and the steps are in the correct order.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="3.3" title="Step 3.3 — Resolve with the route ID" {phaseSlug}>
+  <p>Update your resolve call to specify the route. This tells Restormel to evaluate that route's fallback chain instead of the project default.</p>
+  <p><strong>curl test:</strong></p>
+  <CodeBlock language="bash" code={curlRoute} />
+  <p><strong>In your resolve client:</strong></p>
+  <CodeBlock language="ts" code={resolveClientSnippet} />
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — You can make the <code>routeId</code> configurable per call site. For example, your ingestion pipeline passes <code>routeId: 'ingestion'</code> while your chat handler passes <code>routeId: 'interactive'</code>. This lets different parts of your app have different fallback strategies.
+  </div>
+  <h3>You'll see</h3>
+  <p>The resolve response now reflects the route's first available step: <code>data.routeId</code>, <code>data.providerType</code>, <code>data.modelId</code>, <code>data.explanation</code>.</p>
+  <h3>How to test</h3>
+  <CodeBlock language="bash" code={curlJq} />
+  <p>Expected output: <code>"openai"</code> and <code>"gpt-4o"</code> (or whatever your first step is).</p>
+
+  <h2>Step 3.4 — Test fallback behaviour</h2>
+  <p>To confirm the fallback chain works, make the first step unusable and confirm resolve returns the next enabled step. You create and manage steps via the Steps API (or the dashboard when a full step editor is available).</p>
+  <h3>Step 3.4a — Create steps via the Steps API</h3>
+  <p>You need the route's internal ID (from the dashboard URL when viewing the route). Then create steps with <code>POST .../routes/$ROUTE_ID/steps</code> and body <code>{stepsApiBodyExample}</code>. Add a second step with <code>orderIndex: 1</code> and another provider.</p>
+  <h3>Step 3.4b — Disable the first step and re-resolve</h3>
+  <p>Temporarily disable (or delete) the first step so resolve returns the second step. Then call resolve again with the same route.</p>
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — If you do not yet have a step update endpoint, deleting the first step is the simplest way to force the fallback path; re-create it afterwards.
+  </div>
+  <h3>You'll see</h3>
+  <p>The resolve response returns the <strong>second</strong> step's provider (<code>data.providerType</code> and <code>data.modelId</code>). Restormel skipped the first step and fell through to the next.</p>
+  <h3>How to test</h3>
+  <p>After removing or disabling the first step's credential, call resolve again. Expected: <code>"anthropic"</code> (or your second step's provider). Re-enable (or re-create) the first step after testing.</p>
+  <div class="callout callout-pitfall">
+    <strong>Pitfall</strong> — If you want route resolution to depend on which platform keys are present in your app's environment, use local resolve (Phase 2, Step 2.6) and implement <code>getPlatformKey</code>. The dashboard does not accept raw provider API keys today; it uses Provider Integrations (credential references).
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="3.5" title="Step 3.5 — Wire route IDs into your application" {phaseSlug}>
+  <p>Make the route ID configurable in your resolve wrapper so different parts of your app can use different routes.</p>
+  <CodeBlock language="ts" code={resolveProviderWithRouteIdExample} />
+  <p>Call sites: <code>{callSiteIngestion}</code> for ingestion; <code>{callSiteChat}</code> for chat.</p>
+  <h3>You'll see</h3>
+  <p>No visible change yet (the flag is still off by default). When you test with the flag on, different call sites resolve through different routes.</p>
+  <h3>How to test</h3>
+  <p><code>USE_RESTORMEL_KEYS=true pnpm dev</code> — trigger an ingestion job (should resolve via <code>ingestion</code> route) and a chat request (should resolve via <code>interactive</code> if you created one).</p>
+
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: wire-route-ids</h3>
+    <p><strong>Context docs</strong> (adapt paths for your project): this page; Phase 2 (resolve client and feature flag wrapper).</p>
+    <p><strong>Goal:</strong> Update the resolve wrapper to accept a <code>routeId</code> parameter so different parts of your app use different routes. Update the function signature to <code>{optionsSignature}</code>, pass <code>options.routeId</code> to <code>restormelResolve</code>, then update each call site from your routing inventory to pass the appropriate <code>routeId</code> (e.g. ingestion → <code>ingestion</code>, chat → <code>interactive</code>). Create additional routes in the Dashboard if needed.</p>
+    <p><strong>DO NOT:</strong> Change the legacy path. Hardcode route IDs that don't exist in the dashboard. Remove error handling or legacy fallback. Commit real API keys or secrets.</p>
+    <p><strong>Gate:</strong> Each call site passes a <code>routeId</code>. With the flag on, resolve returns the correct route's provider/model. With the flag off, the app behaves identically. Fallback works (remove a provider credential → resolve returns the next step's provider).</p>
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="3.6" title="Step 3.6 — (Optional) Create a second route" {phaseSlug}>
+  <p>If your app has distinct AI call patterns — for example, fast-and-cheap for autocomplete vs. powerful-and-expensive for analysis — create separate routes with different step orders and models (e.g. <code>autocomplete</code> with gpt-4o-mini first, <code>analysis</code> with claude-sonnet first). Create both in the Dashboard, then use the appropriate <code>routeId</code> in each call site.</p>
+  <h3>How to test</h3>
+  <p>Resolve with <code>routeId: "autocomplete"</code> and <code>routeId: "analysis"</code>; <code>jq '.data.providerType, .data.modelId'</code> should show different providers/models.</p>
+  </WalkthroughStep>
+
+  <p><strong>Checkpoint checklist:</strong> mark each step complete as you finish it.</p>
+  <WalkthroughChecklist phaseSlug={phaseSlug} steps={phase3Steps} />
+
+  <h2>Checkpoint</h2>
+  <p>You now have: at least one named route in the Dashboard with multiple steps (fallback chain); your resolve client passes a <code>routeId</code> so different parts of your app use different routing strategies; fallback verified. The feature flag is still off by default. When on, your app resolves through Restormel routes.</p>
+
+  <WalkthroughPhaseNav {prev} {next} {stepOf} />
+</div>
+
+<style>
+  .doc-content { max-width: var(--rm-container-narrow); }
+  .doc-meta { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-2); }
+  .doc-step { font-weight: var(--font-medium); }
+  .doc-prereqs { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-6); line-height: var(--leading-relaxed); }
+  .doc-prereqs a { color: var(--rm-primary); }
+  .doc-content h1 { font-family: var(--rm-font-display); font-size: var(--text-2xl); margin: 0 0 var(--space-4); }
+  .doc-content h2 { font-size: var(--text-xl); margin: var(--space-8) 0 var(--space-3); }
+  .doc-content h3 { font-size: var(--text-lg); margin: var(--space-4) 0 var(--space-2); }
+  .doc-content p, .doc-content li { color: var(--rm-muted); line-height: var(--leading-relaxed); margin: 0 0 var(--space-4); }
+  .doc-content li { margin-bottom: var(--space-2); }
+  .doc-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+  }
+  .doc-table th, .doc-table td {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--rm-border);
+    text-align: left;
+  }
+  .doc-table th { background: var(--rm-surface-raised); font-weight: var(--font-medium); }
+  .doc-table td { color: var(--rm-muted); }
+  .doc-table code { font-family: var(--rm-font-ui); font-size: 0.9em; }
+  .build-agent-block {
+    margin: var(--space-6) 0;
+    padding: var(--space-4);
+    background: var(--rm-surface);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+  }
+  .build-agent-block h3 { margin-top: 0; }
+</style>

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/phase-4-policies/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/phase-4-policies/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  /** Phase 4 — Policies. Progressive disclosure: checklist + expandable steps. */
+  import { DASHBOARD_BASE } from "$lib/dashboard-base";
+  import { getWalkthroughPrevNext } from "$lib/docs-walkthrough-nav";
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+  import WalkthroughChecklist from "$lib/components/walkthrough/WalkthroughChecklist.svelte";
+  import WalkthroughStep from "$lib/components/walkthrough/WalkthroughStep.svelte";
+  import WalkthroughPhaseNav from "$lib/components/walkthrough/WalkthroughPhaseNav.svelte";
+
+  const { prev, next, stepOf } = getWalkthroughPrevNext("phase-4-policies");
+  const phaseSlug = "phase-4-policies";
+
+  const phase4Steps = [
+    { id: "4.1", label: "Understand policy types" },
+    { id: "4.2", label: "Create a model allowlist" },
+    { id: "4.3", label: "Add a deprecated-model block" },
+    { id: "4.4", label: "Add a budget cap" },
+    { id: "4.5", label: "Test policy stacking" },
+    { id: "4.6", label: "Handle policy errors in your resolve wrapper" },
+  ];
+
+  const curlEvaluate = `curl -s -X POST \\
+  "https://restormel.dev/keys/dashboard/api/policies/evaluate" \\
+  -H "Authorization: Bearer \${RESTORMEL_MANAGEMENT_KEY}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "projectId": "'\${RESTORMEL_PROJECT_ID}'",
+    "environmentId": "production",
+    "modelId": "gpt-4-0314",
+    "providerType": "openai"
+  }' | jq '.data'`;
+
+  const curlStacking = `curl -s -X POST "..." /api/policies/evaluate \\
+  -H "Authorization: Bearer \${RESTORMEL_MANAGEMENT_KEY}" \\
+  -d '{ "projectId": "...", "environmentId": "production", "modelId": "gpt-4o", "providerType": "openai" }' \\
+  | jq '.data'`;
+
+  const policyErrorHandlingSnippet = `} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  if (message.includes('budget') || message.includes('cap')) {
+    console.error('[restormel] Budget cap reached:', message);
+  } else if (message.includes('no_key_available')) {
+    console.warn('[restormel] No provider key available for route');
+  } else {
+    console.error('[restormel] Resolve failed:', message);
+  }
+  // Fall through to legacy
+}`;
+</script>
+
+<svelte:head>
+  <title>Phase 4 — Apply policies — Restormel Keys</title>
+  <meta name="description" content="Add model allowlist, deprecated-model block, budget cap; use the evaluate endpoint with a Management Key (workspace-scoped)." />
+</svelte:head>
+
+<div class="doc-content">
+  <p class="doc-meta"><span class="doc-step">{stepOf}</span></p>
+  <h1>Phase 4 — Apply policies</h1>
+  <p class="doc-prereqs">
+    <strong>Time:</strong> ~15 minutes<br />
+    <strong>Prerequisites:</strong> <a href="/keys/docs/walkthrough/phase-3-routes">Phase 3</a> complete (at least one route with steps configured, resolve returns route-aware results)<br />
+    <strong>You'll need:</strong> Access to the <a href={DASHBOARD_BASE}>Dashboard</a>, your project from Phase 1
+  </p>
+
+  <p>This phase adds guardrails around resolution. Policies constrain which models and providers can be returned, block deprecated models, and cap spend. By the end, your resolve calls are filtered through policies before returning a result, and you can test that policy violations are correctly rejected.</p>
+
+  <WalkthroughStep stepId="4.1" title="Step 4.1 — Understand policy types" defaultOpen={true} {phaseSlug}>
+  <p>Policies are rules attached at the workspace, project, or environment level. They are evaluated during every resolve call. If a policy blocks the resolved model or provider, Restormel falls through to the next step in the route (or returns an error if no step passes).</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Policy type</th><th>What it does</th><th>Example</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><code>model_allowlist</code></td><td>Only these models can be resolved</td><td>Allow gpt-4o, claude-sonnet; block everything else</td></tr>
+      <tr><td><code>model_denylist</code></td><td>These specific models are blocked</td><td>Block gpt-3.5-turbo</td></tr>
+      <tr><td><code>provider_allowlist</code></td><td>Only these providers can be resolved</td><td>Allow openai and anthropic, block google</td></tr>
+      <tr><td><code>provider_denylist</code></td><td>These specific providers are blocked</td><td>Block a provider with a compliance issue</td></tr>
+      <tr><td><code>deprecated_model_block</code></td><td>Block models marked deprecated in the catalog</td><td>Prevent resolution to end-of-life models</td></tr>
+      <tr><td><code>budget_cap</code></td><td>Cap total spend per period</td><td>Max $500/month per environment</td></tr>
+      <tr><td><code>token_cap</code></td><td>Cap total tokens per period</td><td>Max 10M tokens/month</td></tr>
+    </tbody>
+  </table>
+  <p>Policies stack. If you have both a <code>model_allowlist</code> and a <code>budget_cap</code>, both must pass for a model to be resolved.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="4.2" title="Step 4.2 — Create a model allowlist" {phaseSlug}>
+  <p>Start with the most common policy: restricting which models your app can use.</p>
+  <div class="callout callout-note">
+    <strong>Dashboard</strong> — Your project → <strong>Policies</strong> → <strong>Create policy</strong>.
+  </div>
+  <ol>
+    <li><strong>Type:</strong> <code>model_allowlist</code></li>
+    <li><strong>Scope:</strong> Project (applies to all environments and routes in this project)</li>
+    <li><strong>Models:</strong> Add the models you want to allow (e.g. <code>gpt-4o</code>, <code>gpt-4o-mini</code>, <code>claude-sonnet-4-20250514</code>, <code>gemini-2.5-pro</code>)</li>
+    <li><strong>Save</strong> the policy.</li>
+  </ol>
+  <h3>You'll see</h3>
+  <p>The policy listed on the project's Policies page with the type, scope, and allowed models.</p>
+  <h3>How to test</h3>
+  <p>Call resolve; the response <code>data.modelId</code> comes from the first enabled step that passes policies. If your route steps include a blocked model, resolve skips that step and returns the next allowed step.</p>
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — The resolve endpoint does not take an arbitrary <code>model</code> override today. To test allowlisting deterministically, set a route step's <code>modelId</code> to a blocked model, then confirm resolve skips it.
+  </div>
+  <p>Call resolve with an allowed model in your route; expected: one of your allowed models (e.g. <code>"gpt-4o"</code>).</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="4.3" title="Step 4.3 — Add a deprecated-model block" {phaseSlug}>
+  <p>This policy prevents your app from resolving to models that the Restormel model catalog has marked as approaching end-of-life. Even if a route step specifies a deprecated model, this policy blocks it and forces a fallback.</p>
+  <div class="callout callout-note">
+    <strong>Dashboard</strong> — Your project → <strong>Policies</strong> → <strong>Create policy</strong>. Type: <code>deprecated_model_block</code>, Scope: Project. No additional configuration — the policy reads deprecation status from the model catalog automatically.
+  </div>
+  <h3>You'll see</h3>
+  <p>The policy listed on the Policies page. Its effect depends on whether any models in your routes are actually deprecated in the catalog.</p>
+  <h3>How to test</h3>
+  <p>If you have a route step that specifies a model currently marked as deprecated, resolve should skip that step. To verify the policy is active, use the <strong>evaluate</strong> endpoint.</p>
+  <div class="callout callout-security">
+    <strong>Security</strong> — <code>/api/policies/*</code> endpoints are workspace-scoped and do <strong>not</strong> accept a project Gateway Key. Use a <strong>Management Key</strong> for server-to-server checks, or test from the dashboard UI (session cookie).
+  </div>
+  <CodeBlock language="bash" code={curlEvaluate} />
+  <p><strong>Expected:</strong> <code>data.allowed</code> is <code>false</code> when the model/provider combination is blocked by policies; <code>data.violations</code> explains why.</p>
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — The evaluate endpoint is useful for testing policies without actually resolving. It answers "would this model/provider combination pass all policies?" without executing a full route evaluation.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="4.4" title="Step 4.4 — Add a budget cap" {phaseSlug}>
+  <p>Budget caps prevent unexpected spend. When the cap is reached for a period, resolve returns an error rather than allowing more requests.</p>
+  <div class="callout callout-note">
+    <strong>Dashboard</strong> — Your project → <strong>Policies</strong> → <strong>Create policy</strong>. Type: <code>budget_cap</code>, Scope: Environment (e.g. production), Limit: monthly USD (e.g. 500), Period: monthly.
+  </div>
+  <h3>You'll see</h3>
+  <p>The policy listed with the cap amount and period. Current spend tracking appears in the project's usage section.</p>
+  <h3>How to test</h3>
+  <p>Budget caps take effect as usage accumulates. For immediate testing, set a very low cap (e.g. $0.01) and make a few resolve calls with tracked usage; then resolve should fail with a budget error. Restore the cap to a realistic value after testing.</p>
+  <div class="callout callout-pitfall">
+    <strong>Pitfall</strong> — Budget caps depend on usage tracking. The dashboard resolve endpoint logs resolutions but does not automatically know the cost of your provider call unless you report usage back to Restormel. Until usage reporting is part of your integration, treat <code>budget_cap</code> as a config you can create and bind, and validate it via evaluate and later via usage reporting.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="4.5" title="Step 4.5 — Test policy stacking" {phaseSlug}>
+  <p>Policies stack: all active policies must pass for a model to be resolved. Verify by having both a <code>model_allowlist</code> and a <code>deprecated_model_block</code> active, then evaluating a model that is on the allowlist but deprecated (if one exists).</p>
+  <CodeBlock language="bash" code={curlStacking} />
+  <p><strong>Expected:</strong> <code>gpt-4o</code> on the allowlist and not deprecated → allowed. A model on the allowlist but deprecated → blocked by the deprecation policy. The evaluate response shows which policies passed and which blocked.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="4.6" title="Step 4.6 — Handle policy errors in your resolve wrapper" {phaseSlug}>
+  <p>When all route steps are blocked by policies, Restormel returns an error. Your resolve wrapper (from Phase 2) already catches errors and falls back to legacy. Add specific handling for policy errors so you can log or alert on them.</p>
+  <CodeBlock language="ts" code={policyErrorHandlingSnippet} />
+  <p>For budget cap errors, optionally add an alert. For all policy errors, the function still falls through to the legacy path. Do not expose raw Restormel error messages to end-users; translate them into user-friendly messages.</p>
+  </WalkthroughStep>
+
+  <p><strong>Checkpoint checklist:</strong> mark each step complete as you finish it.</p>
+  <WalkthroughChecklist phaseSlug={phaseSlug} steps={phase4Steps} />
+
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: add-policies-and-error-handling</h3>
+    <p><strong>Context docs</strong> (adapt paths for your project): this page (policy types, evaluate endpoint, error handling); Phase 2 (resolve client and error handling).</p>
+    <p><strong>Goal:</strong> Update the resolve error handling to distinguish policy errors (budget cap, model blocked) from network/auth errors. In the catch block, parse the error message for <code>budget</code>/<code>cap</code>, <code>no_key_available</code>, <code>deprecated</code>/<code>blocked</code>; log appropriately; optionally alert on budget cap. Keep falling through to legacy. Add a comment referencing policy types and the evaluate endpoint.</p>
+    <p><strong>DO NOT:</strong> Change the legacy fallback logic. Remove generic error handling. Expose raw Restormel error messages to end-users. Commit real API keys or secrets.</p>
+    <p><strong>Gate:</strong> Policy errors (budget, blocked model) are logged distinctly. Legacy fallback still runs on any Restormel failure. No raw error details leak to end-users.</p>
+  </div>
+
+  <h2>Checkpoint</h2>
+  <p>You now have: a <code>model_allowlist</code> policy; a <code>deprecated_model_block</code> policy; (optional) a <code>budget_cap</code> policy; policy error handling in your resolve wrapper that distinguishes budget, blocked, and generic errors; and the evaluate endpoint as a tool for testing policy combinations without executing a full resolve. Policies are active on the Restormel side. Your app handles policy errors gracefully and falls back to legacy when needed.</p>
+
+  <WalkthroughPhaseNav {prev} {next} {stepOf} />
+</div>
+
+<style>
+  .doc-content { max-width: var(--rm-container-narrow); }
+  .doc-meta { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-2); }
+  .doc-step { font-weight: var(--font-medium); }
+  .doc-prereqs { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-6); line-height: var(--leading-relaxed); }
+  .doc-prereqs a { color: var(--rm-primary); }
+  .doc-content h1 { font-family: var(--rm-font-display); font-size: var(--text-2xl); margin: 0 0 var(--space-4); }
+  .doc-content h3 { font-size: var(--text-lg); margin: var(--space-4) 0 var(--space-2); }
+  .doc-content p, .doc-content li { color: var(--rm-muted); line-height: var(--leading-relaxed); margin: 0 0 var(--space-4); }
+  .doc-content li { margin-bottom: var(--space-2); }
+  .doc-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+  }
+  .doc-table th, .doc-table td {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--rm-border);
+    text-align: left;
+  }
+  .doc-table th { background: var(--rm-surface-raised); font-weight: var(--font-medium); }
+  .doc-table td { color: var(--rm-muted); }
+  .doc-table code { font-family: var(--rm-font-ui); font-size: 0.9em; }
+  .build-agent-block {
+    margin: var(--space-6) 0;
+    padding: var(--space-4);
+    background: var(--rm-surface);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+  }
+  .build-agent-block h3 { margin-top: 0; }
+</style>

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/phase-5-ui/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/phase-5-ui/+page.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+  /** Phase 5 — UI. Progressive disclosure: checklist + expandable steps. */
+  import { getWalkthroughPrevNext } from "$lib/docs-walkthrough-nav";
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+  import WalkthroughChecklist from "$lib/components/walkthrough/WalkthroughChecklist.svelte";
+  import WalkthroughStep from "$lib/components/walkthrough/WalkthroughStep.svelte";
+  import WalkthroughPhaseNav from "$lib/components/walkthrough/WalkthroughPhaseNav.svelte";
+
+  const { prev, next, stepOf } = getWalkthroughPrevNext("phase-5-ui");
+  const phaseSlug = "phase-5-ui";
+
+  const themeCssSnippet = `rk-model-selector,
+.rk-model-selector {
+  --rk-bg: #1a1a1e;
+  --rk-text: #e8e8ec;
+  --rk-accent: #3b82f6;
+  --rk-border: #2a2a2e;
+  --rk-error: #ef4444;
+  --rk-success: #22c55e;
+}`;
+
+  const phase5Steps = [
+    { id: "5.1", label: "Decide what to embed" },
+    { id: "5.2", label: "Embed ModelSelector (Next.js / React)" },
+    { id: "5.3", label: "Embed ModelSelector (SvelteKit)" },
+    { id: "5.4", label: "Embed ModelSelector (Web Components / vanilla)" },
+    { id: "5.5", label: "Filter the model list by policies" },
+    { id: "5.6", label: "Embed KeyManager (optional — for BYOK apps)" },
+    { id: "5.7", label: "Theme the components" },
+  ];
+
+  const resolveProviderModelExample = "resolveProvider({ model: userSelectedModel })";
+</script>
+
+<svelte:head>
+  <title>Phase 5 — Embed the UI — Restormel Keys</title>
+  <meta name="description" content="Embed ModelSelector and KeyManager; policy-filtered model list via server-side proxy; theming with --rk-* CSS." />
+</svelte:head>
+
+<div class="doc-content">
+  <p class="doc-meta"><span class="doc-step">{stepOf}</span></p>
+  <h1>Phase 5 — Embed the UI</h1>
+  <p class="doc-prereqs">
+    <strong>Time:</strong> ~25 minutes<br />
+    <strong>Prerequisites:</strong> <a href="/keys/docs/walkthrough/phase-4-policies">Phase 4</a> complete (routes and policies configured, resolve works with route IDs)<br />
+    <strong>You'll need:</strong> Your app's frontend codebase, the UI packages installed in Phase 1
+  </p>
+
+  <p>This phase puts Restormel's embeddable components into your app so end-users can select models and (optionally) manage their own provider credentials. By the end, your app shows a ModelSelector filtered by your policies and optionally a KeyManager for BYOK, both wired to your backend.</p>
+
+  <WalkthroughStep stepId="5.1" title="Step 5.1 — Decide what to embed" defaultOpen={true} {phaseSlug}>
+  <p>Not every app needs every component. Use this decision matrix:</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>If your app…</th><th>Embed</th><th>Skip</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Lets users choose which AI model to use</td><td><strong>ModelSelector</strong></td><td>—</td></tr>
+      <tr><td>Lets users bring their own provider API keys (BYOK)</td><td><strong>KeyManager</strong></td><td>—</td></tr>
+      <tr><td>Shows cost estimates before running a request</td><td><strong>CostEstimator</strong></td><td>—</td></tr>
+      <tr><td>Only uses platform keys with no user choice</td><td>—</td><td>All UI components (server-side resolve is enough)</td></tr>
+    </tbody>
+  </table>
+  <p>Most apps that reached this phase want <strong>ModelSelector</strong>. KeyManager is for apps where users supply their own OpenAI/Anthropic/Google keys. CostEstimator is a nice-to-have.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="5.2" title="Step 5.2 — Embed ModelSelector (Next.js / React)" {phaseSlug}>
+  <p>Use <code>KeysProvider</code> from <code>@restormel/keys-react</code> and a client component that renders <code>ModelSelector</code> with <code>keys</code>, <code>providers</code>, and <code>onSelect</code>. The <code>onSelect</code> callback should save the user's model preference to your backend (e.g. <code>POST /api/preferences</code> with <code>modelId</code> and <code>providerId</code>).</p>
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — Use <code>next/dynamic</code> with <code>ssr: false</code> to lazy-load the model selector so it doesn't increase your initial page bundle.
+  </div>
+  <h3>You'll see</h3>
+  <p>A model selection UI grouped by provider. Each model shows its availability based on whether a key exists for that provider. Users click a model to select it.</p>
+  <h3>How to test</h3>
+  <p>Start your dev server, navigate to your settings page, confirm the ModelSelector renders with provider groups and models, and click a model to confirm the <code>onSelect</code> callback fires (check the network tab for the preferences API call).</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="5.3" title="Step 5.3 — Embed ModelSelector (SvelteKit)" {phaseSlug}>
+  <p>Import <code>ModelSelector</code> from <code>@restormel/keys-svelte</code> and <code>createKeys</code> plus provider definitions from <code>@restormel/keys</code>. Create the <code>keys</code> instance and pass <code>keys</code>, <code>providers</code>, and <code>onSelect</code> to the component. Wire <code>onSelect</code> to your backend (e.g. <code>POST /api/preferences</code> with <code>modelId</code> and <code>providerId</code>).</p>
+  <h3>You'll see</h3>
+  <p>The same model selection UI as the React version, rendered natively in Svelte.</p>
+  <h3>How to test</h3>
+  <p>Same as Step 5.2: navigate to the settings page, confirm rendering, click a model, verify the callback.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="5.4" title="Step 5.4 — Embed ModelSelector (Web Components / vanilla)" {phaseSlug}>
+  <p>For frameworks not covered by the React or Svelte wrappers, use the Web Components: import <code>@restormel/keys-elements</code>, create the <code>keys</code> instance, set <code>el.keys</code> and <code>el.providers</code> on the <code>&lt;rk-model-selector&gt;</code> element, and listen for the <code>rk-model-selected</code> event to save the selection to your backend.</p>
+  <div class="callout callout-pitfall">
+    <strong>Pitfall</strong> — Web Components require setting object props (<code>keys</code>, <code>providers</code>) via JavaScript properties, not HTML attributes. See <a href="/keys/docs/compatibility">Framework compatibility</a> for the full list.
+  </div>
+  <h3>You'll see</h3>
+  <p>The model selector rendered inside a shadow DOM. Theming applies via <code>--rk-*</code> CSS custom properties.</p>
+  <h3>How to test</h3>
+  <p>Open your page in a browser, confirm the custom element renders, click a model, and confirm the <code>rk-model-selected</code> event fires.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="5.5" title="Step 5.5 — Filter the model list by policies" {phaseSlug}>
+  <p>The ModelSelector shows all models from the configured providers by default. If you have policies (Phase 4) that restrict which models are allowed, filter the model list so users only see valid choices.</p>
+  <p><strong>Server-side filtering (recommended):</strong> Add an API route (e.g. <code>GET /api/allowed-models</code>) that calls the Restormel <strong>evaluate</strong> endpoint for each candidate model, using a <strong>Management Key</strong> (not the Gateway Key). Return only the allowed model IDs to the client and configure the component with that list.</p>
+  <div class="callout callout-security">
+    <strong>Security</strong> — Never call the policies API from the browser. Keep <code>RESTORMEL_MANAGEMENT_KEY</code> server-side only. Use a server proxy like <code>/api/allowed-models</code> and return only the filtered model IDs to the client.
+  </div>
+  <p><strong>Client-side filtering:</strong> If you use local resolve (Phase 2, Step 2.6), you can use <code>keys.entitlements.getAvailableModels(allModelIds)</code> to filter.</p>
+  <h3>You'll see</h3>
+  <p>The ModelSelector shows only models that pass your policies. Blocked models are either hidden or shown as unavailable.</p>
+  <h3>How to test</h3>
+  <p>Add a <code>model_allowlist</code> policy that excludes one model. Refresh the settings page; that model should not appear (or should appear greyed out with "Not allowed").</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="5.6" title="Step 5.6 — Embed KeyManager (optional — for BYOK apps)" {phaseSlug}>
+  <p>If your app lets end-users bring their own API keys, embed the KeyManager component. It provides a settings panel for users to add, validate, list, and remove their provider credentials. Wire <code>onKeyAdded</code> and <code>onKeyRemoved</code> to your backend (e.g. <code>POST /api/keys</code>, <code>DELETE /api/keys/:id</code>).</p>
+  <div class="callout callout-security">
+    <strong>Security</strong> — KeyManager validates keys client-side via a lightweight test call to the provider. Raw key material is never sent to Restormel. Your backend should store only hashed keys and metadata (provider, label, key prefix). Never log or expose raw keys.
+  </div>
+  <h3>You'll see</h3>
+  <p>A settings panel with an empty state, a form to select a provider and paste a key, validation feedback, a list of stored keys (masked), and delete buttons.</p>
+  <h3>How to test</h3>
+  <p>Navigate to settings, add a key (test/invalid is fine to confirm validation), confirm <code>onKeyAdded</code> fires and your API receives the request. With a valid key, confirm validation passes. Delete the key and confirm <code>onKeyRemoved</code> fires.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="5.7" title="Step 5.7 — Theme the components" {phaseSlug}>
+  <p>Restormel UI components use <code>--rk-*</code> CSS custom properties for theming. Override them to match your app:</p>
+  <CodeBlock language="css" code={themeCssSnippet} />
+  <p>The components ship with dark (`.rk-dark`) and light (`.rk-light`) presets.</p>
+  <h3>You'll see</h3>
+  <p>Components render with your app's colour scheme.</p>
+  <h3>How to test</h3>
+  <p>Change a token (e.g. <code>--rk-accent</code>) to something distinct; confirm the accent colour updates on buttons and highlights.</p>
+  </WalkthroughStep>
+
+  <p><strong>Checkpoint checklist:</strong> mark each step complete as you finish it.</p>
+  <WalkthroughChecklist phaseSlug={phaseSlug} steps={phase5Steps} />
+
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: embed-ui-components</h3>
+    <p><strong>Context docs</strong> (adapt paths for your project): this page; <a href="/keys/docs/compatibility">Framework compatibility</a> (which package for which framework).</p>
+    <p><strong>Goal:</strong> Embed ModelSelector (and optionally KeyManager) into your app's settings page. Use KeysProvider + client component for Next.js/React; direct import for SvelteKit; <code>@restormel/keys-elements</code> and properties for Web Components. Wire <code>onSelect</code> / <code>rk-model-selected</code> to save preferences; wire KeyManager callbacks to your key storage API. Add <code>--rk-*</code> overrides. Handle loading, error, and empty states. Verify rendering, callbacks, theme, and keyboard navigation.</p>
+    <p><strong>DO NOT:</strong> Import UI packages in server-only code. Log or expose raw API keys. Skip empty/error/loading states. Hardcode model lists. Commit real API keys or secrets.</p>
+    <p><strong>Gate:</strong> ModelSelector renders and fires onSelect with modelId and providerId. (If BYOK) KeyManager add/remove callbacks work. Theme tokens apply. Loading, error, empty states handled. Keyboard navigation works.</p>
+  </div>
+
+  <h2>Checkpoint</h2>
+  <p>You now have: ModelSelector embedded and filtered by your policies; (optional) KeyManager for BYOK with callbacks wired to your backend; components themed via <code>--rk-*</code>; callbacks saving user selections. The UI components work alongside your resolve integration from Phases 2–4. When a user selects a model, your backend can pass that to <code>{resolveProviderModelExample}</code> and Restormel evaluates it against routes and policies.</p>
+
+  <WalkthroughPhaseNav {prev} {next} {stepOf} />
+</div>
+
+<style>
+  .doc-content { max-width: var(--rm-container-narrow); }
+  .doc-meta { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-2); }
+  .doc-step { font-weight: var(--font-medium); }
+  .doc-prereqs { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-6); line-height: var(--leading-relaxed); }
+  .doc-prereqs a { color: var(--rm-primary); }
+  .doc-content h1 { font-family: var(--rm-font-display); font-size: var(--text-2xl); margin: 0 0 var(--space-4); }
+  .doc-content h2 { font-size: var(--text-xl); margin: var(--space-8) 0 var(--space-3); }
+  .doc-content h3 { font-size: var(--text-lg); margin: var(--space-4) 0 var(--space-2); }
+  .doc-content p { color: var(--rm-muted); line-height: var(--leading-relaxed); margin: 0 0 var(--space-4); }
+  .doc-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+  }
+  .doc-table th, .doc-table td {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--rm-border);
+    text-align: left;
+  }
+  .doc-table th { background: var(--rm-surface-raised); font-weight: var(--font-medium); }
+  .doc-table td { color: var(--rm-muted); }
+  .build-agent-block {
+    margin: var(--space-6) 0;
+    padding: var(--space-4);
+    background: var(--rm-surface);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+  }
+  .build-agent-block h3 { margin-top: 0; }
+</style>

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/phase-6-golive/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/phase-6-golive/+page.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  /** Phase 6 — Go live. Progressive disclosure: checklist + expandable steps. */
+  import { DASHBOARD_BASE } from "$lib/dashboard-base";
+  import { getWalkthroughPrevNext } from "$lib/docs-walkthrough-nav";
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+  import WalkthroughChecklist from "$lib/components/walkthrough/WalkthroughChecklist.svelte";
+  import WalkthroughStep from "$lib/components/walkthrough/WalkthroughStep.svelte";
+  import WalkthroughPhaseNav from "$lib/components/walkthrough/WalkthroughPhaseNav.svelte";
+
+  const { prev, next, stepOf } = getWalkthroughPrevNext("phase-6-golive");
+  const phaseSlug = "phase-6-golive";
+
+  const phase6Steps = [
+    { id: "6.1", label: "Pre-cutover checklist" },
+    { id: "6.2", label: "Enable the flag for a small percentage (parallel run)" },
+    { id: "6.3", label: "Full cutover" },
+    { id: "6.4", label: "Post-cutover verification" },
+    { id: "6.5", label: "Remove legacy routing code" },
+  ];
+
+  const rolloutSnippet = `const RESTORMEL_ROLLOUT_PERCENT = parseInt(
+  process.env.RESTORMEL_ROLLOUT_PERCENT ?? '0',
+  10
+);
+
+export const USE_RESTORMEL_KEYS =
+  process.env.USE_RESTORMEL_KEYS === 'true' ||
+  (RESTORMEL_ROLLOUT_PERCENT > 0 && Math.random() * 100 < RESTORMEL_ROLLOUT_PERCENT);`;
+
+  const cutoverEnvSnippet = `# In your production environment variables
+USE_RESTORMEL_KEYS=true
+RESTORMEL_ROLLOUT_PERCENT=100  # if using percentage-based rollout`;
+
+  const doctorValidateSnippet = `npx @restormel/keys-cli doctor
+npx @restormel/keys-cli validate`;
+</script>
+
+<svelte:head>
+  <title>Phase 6 — Go live — Restormel Keys</title>
+  <meta name="description" content="Parallel run, phased traffic shift, cutover, post-cutover verification, smoke test, legacy code removal." />
+</svelte:head>
+
+<div class="doc-content">
+  <p class="doc-meta"><span class="doc-step">{stepOf}</span></p>
+  <h1>Phase 6 — Go live</h1>
+  <p class="doc-prereqs">
+    <strong>Time:</strong> ~30 minutes (cutover) + monitoring period<br />
+    <strong>Prerequisites:</strong> <a href="/keys/docs/walkthrough/phase-5-ui">Phase 5</a> complete (resolve, routes, policies, and UI all working with the feature flag on in development)<br />
+    <strong>You'll need:</strong> Access to your deployment pipeline, monitoring/logging, the <a href={DASHBOARD_BASE}>Dashboard</a>
+  </p>
+
+  <p>This phase moves your Restormel Keys integration from development into production traffic. The strategy is conservative: parallel run, phased traffic shift, verify, then cut over fully. By the end, your production app resolves through Restormel and the legacy routing code is retired.</p>
+
+  <WalkthroughStep stepId="6.1" title="Step 6.1 — Pre-cutover checklist" defaultOpen={true} {phaseSlug}>
+  <p>Before enabling the feature flag in production, verify everything works in a staging or preview environment.</p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Check</th><th>How to verify</th><th>Pass?</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Resolve works</td><td><code>USE_RESTORMEL_KEYS=true</code> in staging; make AI requests; confirm correct provider/model</td><td>☐</td></tr>
+      <tr><td>Fallback works</td><td>Remove a provider credential in dashboard; confirm resolve returns next step</td><td>☐</td></tr>
+      <tr><td>Policy enforcement works</td><td>Request a blocked model; confirm it's rejected or falls through</td><td>☐</td></tr>
+      <tr><td>Error fallback works</td><td>Set invalid Gateway Key; confirm legacy routing takes over</td><td>☐</td></tr>
+      <tr><td>ModelSelector renders</td><td>Open settings page; confirm component loads and selection works</td><td>☐</td></tr>
+      <tr><td>(If BYOK) KeyManager works</td><td>Add/remove a test key; confirm callbacks fire</td><td>☐</td></tr>
+      <tr><td><code>keys doctor</code> passes</td><td>Run <code>npx @restormel/keys-cli doctor</code> in the staging env</td><td>☐</td></tr>
+      <tr><td><code>keys validate</code> passes</td><td>Run <code>npx @restormel/keys-cli validate</code> to re-check stored keys</td><td>☐</td></tr>
+      <tr><td>No secrets committed</td><td>Run <code>scripts/check-secrets.sh</code> or <code>git log --diff-filter=A -- '*.env'</code></td><td>☐</td></tr>
+      <tr><td>Dashboard logs show requests</td><td>Check the project's usage/logs section in the dashboard</td><td>☐</td></tr>
+    </tbody>
+  </table>
+  <div class="callout callout-pitfall">
+    <strong>Pitfall</strong> — Do not skip the error fallback check. The most dangerous production failure mode is Restormel being unreachable and your app not falling back to legacy. Confirm this works before proceeding.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="6.2" title="Step 6.2 — Enable the flag for a small percentage (parallel run)" {phaseSlug}>
+  <p>If your app supports percentage-based rollout (e.g. via LaunchDarkly, Vercel Edge Config, Cloudflare Workers, or a simple random check), start with a small percentage of traffic using Restormel.</p>
+  <CodeBlock language="ts" code={rolloutSnippet} />
+  <p><strong>Rollout sequence:</strong></p>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Step</th><th><code>RESTORMEL_ROLLOUT_PERCENT</code></th><th>What to watch</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>1</td><td>5</td><td>Errors in logs, latency increase, correct provider in responses</td></tr>
+      <tr><td>2</td><td>25</td><td>Same, at higher volume</td></tr>
+      <tr><td>3</td><td>50</td><td>Compare Restormel path vs legacy path outcomes</td></tr>
+      <tr><td>4</td><td>100</td><td>Full traffic through Restormel</td></tr>
+    </tbody>
+  </table>
+  <p>If you don't have percentage-based rollout, use the boolean flag: <code>USE_RESTORMEL_KEYS=true</code> for the full cutover (Step 6.3).</p>
+  <h3>You'll see</h3>
+  <p>A mix of requests going through Restormel (your app logs include <code>providerType</code> / <code>modelId</code> from resolve) and legacy. The ratio roughly matches your rollout percentage.</p>
+  <h3>How to test</h3>
+  <p>Check your application logs. Requests that went through Restormel log the resolved provider and source. Requests that went through legacy log the legacy provider. Both succeed without user-facing errors.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="6.3" title="Step 6.3 — Full cutover" {phaseSlug}>
+  <p>When you're confident from the parallel run, enable Restormel for all traffic:</p>
+  <CodeBlock language="bash" code={cutoverEnvSnippet} />
+  <p>Deploy the env change. Monitor for 15–30 minutes.</p>
+  <h3>You'll see</h3>
+  <p>All AI requests resolve through Restormel. Your logs show the resolved <code>providerType</code> / <code>modelId</code> for every request. The dashboard shows request volume in the project's usage section.</p>
+  <h3>How to test</h3>
+  <p>Verify no requests are going through legacy (e.g. <code>grep -c '"source":"legacy"' /path/to/your/app.log</code> — expected 0). Check the dashboard: <strong>Projects → your project → Usage</strong>. Request counts match your expected traffic.</p>
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — Keep the legacy fallback code in place for at least one release cycle after cutover. If something unexpected happens, you can flip the flag back to <code>false</code> and instantly restore the old behaviour.
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="6.4" title="Step 6.4 — Post-cutover verification" {phaseSlug}>
+  <p>Run a comprehensive check within the first hour after cutover.</p>
+  <p><strong>CLI checks:</strong></p>
+  <CodeBlock language="bash" code={doctorValidateSnippet} />
+  <p><strong>Dashboard checks:</strong> Usage (request count non-zero and growing, no error spikes); Routes (traffic against configured routes); Policies (no unexpected violations); Provider credentials (all show "valid").</p>
+  <p><strong>Application checks:</strong> Make a request through each major code path; confirm correct provider and model. Test fallback (temporarily remove a provider credential, confirm next step is used, restore). Test a policy block (request a model not on the allowlist). Check latency; resolve adds a network round-trip (typically &lt;100ms).</p>
+  <p><strong>Smoke test script:</strong> Create a script that (1) calls the resolve endpoint and prints provider, model, explanation; (2) calls the policy evaluate endpoint for an allowed model; (3) runs <code>keys doctor</code>. Use <code>RESTORMEL_GATEWAY_KEY</code> and <code>RESTORMEL_MANAGEMENT_KEY</code> from the environment; never hardcode secrets.</p>
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: create-smoke-test</h3>
+    <p><strong>Context docs</strong> (adapt for your project): this page; <a href="/keys/docs/walkthrough/phase-2-resolve">Phase 2 — Resolve</a>; <a href="/keys/docs/walkthrough/phase-4-policies">Phase 4 — Policies</a>.</p>
+    <p><strong>Goal:</strong> Create a post-cutover smoke test script. It must: call resolve and print provider/model/source; call policy evaluate for an allowed (and optionally blocked) model; run <code>keys doctor</code> and <code>keys validate</code>; read keys and project ID from env; exit 0 if all pass, 1 if any fail. Add <code>smoke:restormel</code> to <code>package.json</code> scripts.</p>
+    <p><strong>DO NOT:</strong> Hardcode real API keys, project IDs, or URLs. Make the script destructive. Skip doctor/validate. Commit real secrets.</p>
+    <p><strong>Gate:</strong> <code>pnpm run smoke:restormel</code> exits 0 in staging; script prints resolved provider and policy results; no secrets hardcoded.</p>
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="6.5" title="Step 6.5 — Remove legacy routing code" {phaseSlug}>
+  <p>Once you're confident Restormel is handling all traffic correctly (at least one full release cycle with the flag at 100%), clean up:</p>
+  <ol>
+    <li><strong>Remove the feature flag.</strong> The Restormel path is now the only path.</li>
+    <li><strong>Remove the legacy resolve function.</strong> The legacy fallback in your resolve module is no longer needed.</li>
+    <li><strong>Remove the inventory items marked "REMOVE" in Phase 0.</strong> Custom router, hardcoded model lists, custom fallback chains, custom model picker UI.</li>
+    <li><strong>Remove unused env vars.</strong> Any <code>DEFAULT_MODEL</code>, <code>AI_PROVIDER</code>, or provider-specific routing env vars that Restormel replaces.</li>
+    <li><strong>Keep the error fallback to a sensible default.</strong> Your resolve wrapper should still handle Restormel errors gracefully (e.g. return a hardcoded default or a user-facing error).</li>
+  </ol>
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: remove-legacy-routing</h3>
+    <p><strong>Context docs</strong> (adapt for your project): this page (Step 6.5); <a href="/keys/docs/walkthrough/phase-0-inventory">Phase 0 — Inventory</a> ("REMOVE" items); <a href="/keys/docs/walkthrough/phase-2-resolve">Phase 2 — Resolve</a> (feature flag and legacy fallback to remove).</p>
+    <p><strong>Goal:</strong> Remove legacy routing code. Delete every "REMOVE" item from the routing inventory. In the resolve module: remove the feature flag and <code>legacyResolve</code>; resolve always uses Restormel; keep try/catch with a safe default or user-facing error on failure. Remove the flag from <code>.env.example</code>. Remove replaced UI (custom model picker/BYOK). Remove unused routing env vars. Run tests and the smoke test.</p>
+    <p><strong>DO NOT:</strong> Remove billing, auth, session, or orchestration code. Remove Restormel error handling. Remove env vars other parts of the app use. Remove the smoke test script. Commit real secrets.</p>
+    <p><strong>Gate:</strong> All "REMOVE" items deleted; feature flag gone; <code>resolveProvider</code> always uses Restormel; tests and smoke test pass.</p>
+  </div>
+  </WalkthroughStep>
+
+  <p><strong>Checkpoint checklist:</strong> mark each step complete as you finish it.</p>
+  <WalkthroughChecklist phaseSlug={phaseSlug} steps={phase6Steps} />
+
+  <h2>Checkpoint</h2>
+  <p>You now have: production traffic resolving through Restormel Keys; a smoke test script for ongoing verification; (after Step 6.5) legacy routing code removed and Restormel as the single source of truth; the dashboard showing live traffic, route usage, and policy enforcement.</p>
+  <p>Your integration is complete. For ongoing operations, see <a href="/keys/docs/walkthrough/verification-strategy">Verification strategy</a>.</p>
+
+  <WalkthroughPhaseNav {prev} {next} {stepOf} />
+</div>
+
+<style>
+  .doc-content { max-width: var(--rm-container-narrow); }
+  .doc-meta { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-2); }
+  .doc-step { font-weight: var(--font-medium); }
+  .doc-prereqs { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-6); line-height: var(--leading-relaxed); }
+  .doc-prereqs a { color: var(--rm-primary); }
+  .doc-content h1 { font-family: var(--rm-font-display); font-size: var(--text-2xl); margin: 0 0 var(--space-4); }
+  .doc-content h2 { font-size: var(--text-xl); margin: var(--space-8) 0 var(--space-3); }
+  .doc-content h3 { font-size: var(--text-lg); margin: var(--space-4) 0 var(--space-2); }
+  .doc-content p, .doc-content li { color: var(--rm-muted); line-height: var(--leading-relaxed); margin: 0 0 var(--space-4); }
+  .doc-content ol { margin: 0 0 var(--space-4); padding-left: var(--space-5); }
+  .doc-content li { margin-bottom: var(--space-2); }
+  .doc-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+  }
+  .doc-table th, .doc-table td {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--rm-border);
+    text-align: left;
+  }
+  .doc-table th { background: var(--rm-surface-raised); font-weight: var(--font-medium); }
+  .doc-table td { color: var(--rm-muted); }
+  .doc-table code { font-family: var(--rm-font-ui); font-size: 0.9em; }
+  .build-agent-block {
+    margin: var(--space-6) 0;
+    padding: var(--space-4);
+    background: var(--rm-surface);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+  }
+  .build-agent-block h3 { margin-top: 0; }
+</style>

--- a/apps/dashboard/src/routes/keys/docs/walkthrough/verification-strategy/+page.svelte
+++ b/apps/dashboard/src/routes/keys/docs/walkthrough/verification-strategy/+page.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+  /** Verification strategy. Progressive disclosure: checklist + expandable sections. */
+  import { DASHBOARD_BASE } from "$lib/dashboard-base";
+  import { getWalkthroughPrevNext } from "$lib/docs-walkthrough-nav";
+  import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+  import WalkthroughChecklist from "$lib/components/walkthrough/WalkthroughChecklist.svelte";
+  import WalkthroughStep from "$lib/components/walkthrough/WalkthroughStep.svelte";
+  import WalkthroughPhaseNav from "$lib/components/walkthrough/WalkthroughPhaseNav.svelte";
+
+  const { prev, next, stepOf } = getWalkthroughPrevNext("verification-strategy");
+  const phaseSlug = "verification-strategy";
+
+  const verificationSteps = [
+    { id: "layers", label: "1. Verification layers" },
+    { id: "dashboard", label: "2. Dashboard checks" },
+    { id: "cli", label: "3. CLI checks" },
+    { id: "smoke", label: "4. Smoke tests" },
+    { id: "monitoring", label: "5. Ongoing monitoring recommendations" },
+    { id: "schedule", label: "6. Verification schedule summary" },
+  ];
+</script>
+
+<svelte:head>
+  <title>Verification strategy — Restormel Keys</title>
+  <meta name="description" content="Dashboard checks, CLI checks, and smoke tests for Restormel Keys — during rollout and ongoing." />
+</svelte:head>
+
+<div class="doc-content">
+  <p class="doc-meta"><span class="doc-step">{stepOf}</span></p>
+  <h1>Verification strategy</h1>
+  <p class="doc-intro">Canonical verification approach for Restormel Keys integrations — during rollout and ongoing.</p>
+  <p>This document defines three layers of verification: <strong>dashboard checks</strong> (visual, no code), <strong>CLI checks</strong> (terminal, scriptable), and <strong>smoke tests</strong> (HTTP, automatable). Use all three during cutover (Phase 6) and the first two on an ongoing basis.</p>
+
+  <WalkthroughStep stepId="layers" title="1. Verification layers" defaultOpen={true} {phaseSlug}>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Layer</th><th>When to use</th><th>Who runs it</th><th>Automatable?</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Dashboard</strong></td><td>After any config change (route, policy, credential); during cutover monitoring</td><td>Human (or browser automation)</td><td>Partially</td></tr>
+      <tr><td><strong>CLI</strong></td><td>After install, before deploy, in CI, during cutover</td><td>Human or CI</td><td>Yes</td></tr>
+      <tr><td><strong>Smoke tests</strong></td><td>After deploy, during cutover, as a scheduled health check</td><td>CI or cron</td><td>Yes</td></tr>
+    </tbody>
+  </table>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="dashboard" title="2. Dashboard checks" {phaseSlug}>
+  <p>Open the <a href={DASHBOARD_BASE}>Dashboard</a> and verify the following. These checks require no code — just visual confirmation.</p>
+
+  <h3>2.1 Project health</h3>
+  <table class="doc-table">
+    <thead>
+      <tr><th>What to check</th><th>Where</th><th>Expected</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Project exists</td><td>Projects list</td><td>Your project is listed</td></tr>
+      <tr><td>Environment exists</td><td>Project → Environments</td><td><code>production</code> (and <code>staging</code> if used)</td></tr>
+      <tr><td>Gateway Key exists</td><td>Project → API Keys</td><td>At least one key with <code>rk_…</code> prefix</td></tr>
+      <tr><td>Provider credentials valid</td><td>Project → Provider Credentials</td><td>Green "valid" status for each configured provider</td></tr>
+    </tbody>
+  </table>
+
+  <h3>2.2 Route health</h3>
+  <table class="doc-table">
+    <thead>
+      <tr><th>What to check</th><th>Where</th><th>Expected</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Routes exist</td><td>Project → Routes</td><td>At least one route (e.g. <code>ingestion</code>, <code>interactive</code>)</td></tr>
+      <tr><td>Steps in correct order</td><td>Route detail</td><td>Steps listed in your intended fallback order</td></tr>
+      <tr><td>Route mode correct</td><td>Route detail</td><td><code>fallback_chain</code> (or your intended mode)</td></tr>
+    </tbody>
+  </table>
+
+  <h3>2.3 Policy health</h3>
+  <table class="doc-table">
+    <thead>
+      <tr><th>What to check</th><th>Where</th><th>Expected</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Policies exist</td><td>Project → Policies</td><td>At least one policy (e.g. <code>model_allowlist</code>)</td></tr>
+      <tr><td>Policy scope correct</td><td>Policy detail</td><td>Scoped to the right project/environment</td></tr>
+      <tr><td>No conflicting policies</td><td>Policies list</td><td>No two policies that contradict each other</td></tr>
+    </tbody>
+  </table>
+
+  <h3>2.4 Usage and logs</h3>
+  <table class="doc-table">
+    <thead>
+      <tr><th>What to check</th><th>Where</th><th>Expected</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Request count non-zero</td><td>Project → Usage</td><td>After cutover, requests appear</td></tr>
+      <tr><td>No error spikes</td><td>Project → Usage / Logs</td><td>Error rate comparable to or lower than pre-cutover</td></tr>
+      <tr><td>Correct route distribution</td><td>Project → Usage</td><td>Traffic hitting the expected routes</td></tr>
+    </tbody>
+  </table>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="cli" title="3. CLI checks" {phaseSlug}>
+  <p>These checks run in a terminal and can be scripted into CI.</p>
+
+  <h3>3.1 <code>keys doctor</code></h3>
+  <CodeBlock language="bash" code="npx @restormel/keys-cli doctor" />
+  <p><strong>Checks:</strong> Framework detection, packages installed, config file validity, and whether local provider keys are present (if you use them).</p>
+  <p><strong>Expected:</strong> Exit code 0, all checks green.</p>
+  <p><strong>When to run:</strong> After install (Phase 1), before every deploy, in CI on every PR.</p>
+
+  <h3>3.2 <code>keys validate</code></h3>
+  <CodeBlock language="bash" code="npx @restormel/keys-cli validate" />
+  <p><strong>Checks:</strong> Re-validates all stored provider keys (makes lightweight test calls to each provider).</p>
+  <p><strong>Expected:</strong> Exit code 0 if all keys are valid. Exit code 1 if any key is invalid or expired.</p>
+  <p><strong>When to run:</strong> Before deploy, in CI on a schedule (e.g. daily), after rotating any provider keys.</p>
+  <div class="callout callout-tip">
+    <strong>Tip</strong> — <code>keys validate</code> with exit code 1 is designed for CI gates. Add it to your deploy pipeline so deploys fail if a provider key has been revoked or expired.
+  </div>
+  <CodeBlock language="yaml" code={`# .github/workflows/deploy.yml
+- name: Validate Restormel keys
+  run: npx @restormel/keys-cli validate`} />
+
+  <h3>3.3 <code>keys estimate</code> (optional)</h3>
+  <CodeBlock language="bash" code="npx @restormel/keys-cli estimate gpt-4o --input 1000 --output 500" />
+  <p><strong>Checks:</strong> Returns the estimated cost for a given model and token count.</p>
+  <p><strong>When to run:</strong> Before enabling a new model in a route, to understand cost implications.</p>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="smoke" title="4. Smoke tests" {phaseSlug}>
+  <p>HTTP-based tests that verify the resolve endpoint and policy evaluation. Automatable; run after every deploy and on a schedule.</p>
+
+  <h3>4.1 Resolve smoke test</h3>
+  <p>POST to the resolve endpoint with your project ID, environment, and route ID. Expect HTTP 200 and a non-null <code>providerType</code> (and <code>modelId</code>) in the response. Use <code>RESTORMEL_GATEWAY_KEY</code> for auth.</p>
+  <p><strong>Expected:</strong> HTTP 200, non-null provider in response.</p>
+
+  <h3>4.2 Fallback smoke test</h3>
+  <p>Create a dedicated <strong>test route</strong> in the dashboard with a deliberately failing first step (e.g. invalid provider), then a second step (e.g. OpenAI). Call resolve for that route and confirm the result is the fallback provider.</p>
+  <p><strong>Expected:</strong> Resolve returns the fallback step's provider.</p>
+
+  <h3>4.3 Policy smoke test</h3>
+  <p>Call the policy evaluate endpoint for an allowed model (expect <code>allowed: true</code>) and for a blocked model (expect <code>allowed: false</code>). Use <code>RESTORMEL_MANAGEMENT_KEY</code> for auth.</p>
+
+  <h3>4.4 Combined smoke test script</h3>
+  <p>The script from Phase 6 (Step 6.4) combines all checks:</p>
+  <CodeBlock language="bash" code="pnpm run smoke:restormel" />
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="monitoring" title="5. Ongoing monitoring recommendations" {phaseSlug}>
+  <table class="doc-table">
+    <thead>
+      <tr><th>What</th><th>How</th><th>Frequency</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Resolve latency</td><td>Log time per <code>restormelResolve()</code> call; alert if p95 &gt; 200ms</td><td>Every request</td></tr>
+      <tr><td>Resolve errors</td><td>Count errors from resolve client; alert on spike</td><td>Every request</td></tr>
+      <tr><td>Fallback rate</td><td>Count fallback-to-legacy or next-step events; alert if &gt; 5%</td><td>Every request</td></tr>
+      <tr><td>Credential expiry</td><td><code>keys validate</code> in CI; alert on exit code 1</td><td>Daily</td></tr>
+      <tr><td>Policy violations</td><td>Dashboard logs; alert if unexpected blocks</td><td>Daily</td></tr>
+      <tr><td>Budget utilisation</td><td>Dashboard usage; alert at 80% of cap</td><td>Daily</td></tr>
+      <tr><td>Config drift</td><td><code>keys doctor</code> in CI; alert on warnings</td><td>Every deploy</td></tr>
+    </tbody>
+  </table>
+
+  <div class="build-agent-block">
+    <h3>Build-agent prompt: add-ci-verification</h3>
+    <p><strong>Context docs</strong> (adapt for your project): this page; <a href="/keys/docs/walkthrough/phase-6-golive">Phase 6 — Go live</a> (smoke test script).</p>
+    <p><strong>Goal:</strong> Add Restormel Keys verification steps to your CI pipeline. Add a step after build: <code>npx @restormel/keys-cli doctor</code> (fail on non-zero exit). Add <code>npx @restormel/keys-cli validate</code> (fail on non-zero exit; requires <code>RESTORMEL_GATEWAY_KEY</code> as a CI secret). Use a dedicated staging key in CI, not production. Optionally add post-deploy <code>pnpm run smoke:restormel</code> (gate behind env if staging isn't available in CI).</p>
+    <p><strong>DO NOT:</strong> Use the production Gateway Key in CI. Commit secrets to the workflow file. Make the smoke test block deploys if it hits an unavailable endpoint.</p>
+    <p><strong>Gate:</strong> CI runs <code>keys doctor</code> and <code>keys validate</code> on every PR; both pass; Gateway Key is a CI secret.</p>
+  </div>
+  </WalkthroughStep>
+
+  <WalkthroughStep stepId="schedule" title="6. Verification schedule summary" {phaseSlug}>
+  <table class="doc-table">
+    <thead>
+      <tr><th>Event</th><th>Checks to run</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Phase 1 complete</strong></td><td><code>keys doctor</code></td></tr>
+      <tr><td><strong>Phase 2 complete</strong></td><td><code>keys doctor</code>, resolve curl test</td></tr>
+      <tr><td><strong>Phase 3 complete</strong></td><td>Resolve with route ID, fallback test</td></tr>
+      <tr><td><strong>Phase 4 complete</strong></td><td>Policy evaluate (allowed + blocked)</td></tr>
+      <tr><td><strong>Phase 5 complete</strong></td><td>Visual: ModelSelector renders, callbacks fire</td></tr>
+      <tr><td><strong>Phase 6 cutover</strong></td><td>Full smoke test, dashboard usage, error rate</td></tr>
+      <tr><td><strong>Ongoing</strong></td><td><code>keys doctor</code> + <code>keys validate</code> in CI; smoke test on schedule; dashboard monitoring</td></tr>
+    </tbody>
+  </table>
+  </WalkthroughStep>
+
+  <p><strong>Checkpoint checklist:</strong> mark each section complete as you read it.</p>
+  <WalkthroughChecklist phaseSlug={phaseSlug} steps={verificationSteps} />
+
+  <p class="doc-footer">See the <a href="/keys/docs/walkthrough">Walkthrough</a> index for the full phase listing and related docs.</p>
+
+  <WalkthroughPhaseNav {prev} {next} {stepOf} />
+</div>
+
+<style>
+  .doc-content { max-width: var(--rm-container-narrow); }
+  .doc-meta { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-2); }
+  .doc-step { font-weight: var(--font-medium); }
+  .doc-intro { font-size: var(--text-sm); color: var(--rm-muted); margin: 0 0 var(--space-2); font-style: italic; }
+  .doc-content h1 { font-family: var(--rm-font-display); font-size: var(--text-2xl); margin: 0 0 var(--space-4); }
+  .doc-content h3 { font-size: var(--text-lg); margin: var(--space-4) 0 var(--space-2); }
+  .doc-content p { color: var(--rm-muted); line-height: var(--leading-relaxed); margin: 0 0 var(--space-4); }
+  .doc-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+  }
+  .doc-table th, .doc-table td {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--rm-border);
+    text-align: left;
+  }
+  .doc-table th { background: var(--rm-surface-raised); font-weight: var(--font-medium); }
+  .doc-table td { color: var(--rm-muted); }
+  .doc-table code { font-family: var(--rm-font-ui); font-size: 0.9em; }
+  .build-agent-block {
+    margin: var(--space-6) 0;
+    padding: var(--space-4);
+    background: var(--rm-surface);
+    border: 1px solid var(--rm-border);
+    border-radius: var(--radius-md);
+  }
+  .build-agent-block h3 { margin-top: 0; }
+  .doc-footer { margin-top: var(--space-6); font-size: var(--text-sm); color: var(--rm-muted); }
+  .doc-footer a { color: var(--rm-primary); }
+</style>

--- a/apps/dashboard/src/routes/keys/pricing/+page.svelte
+++ b/apps/dashboard/src/routes/keys/pricing/+page.svelte
@@ -187,9 +187,6 @@
     color: var(--rm-muted);
     margin: 0 0 var(--space-4);
   }
-  .checkout-message-error {
-    color: var(--coral-alert);
-  }
   .visually-hidden {
     position: absolute;
     width: 1px;

--- a/docs/00-master-index.md
+++ b/docs/00-master-index.md
@@ -31,6 +31,17 @@ This build pack contains everything needed to take Restormel Keys from concept t
 | — | `COMPONENT-INVENTORY.md` | Full component inventory (atoms, molecules, organisms, graph components). |
 | — | `design-tokens.css` | Reference implementation of DESIGN-TOKENS.md as CSS custom properties. |
 
+### Walkthrough (public integration docs)
+
+| # | Document | What it covers |
+|---|----------|----------------|
+| — | `docs/walkthrough/00-index.md` | **Entry point.** Master index and reading order for the integration walkthrough. |
+| — | `docs/walkthrough/00-walkthrough-ia.md` | Docs IA: placement in Svelte docs, page map, flow diagram, cross-links. |
+| — | `docs/walkthrough/01-writing-style-guide.md` | Terminology, auth cheat-sheet (Gateway vs Management Key vs session), callouts, code conventions. |
+| — | `docs/walkthrough/02-phase-0-inventory.md` … `11-prompt-index.md` | Phase 0–6 pages, migration paths, verification, prompt index. |
+
+Documentation lives in the Svelte/SvelteKit app (`/keys/docs/` and `/keys/docs/walkthrough/`); Zuplo is used for the Cloud API gateway. Use the walkthrough as the canonical onboarding journey for integrating Restormel Keys.
+
 ### Prompt packs (Cursor-targeted)
 
 | # | Document | Phase | Prompts | Est. effort |
@@ -66,7 +77,7 @@ This build pack contains everything needed to take Restormel Keys from concept t
 | CI/CD | GitHub Actions | Already operational in SOPHIA. Copy and adapt. |
 | IaC | Pulumi | Already operational in SOPHIA. Copy and simplify. |
 | Auth | Firebase Auth (GitHub sign-in) | Already operational in SOPHIA. Developer audience prefers GitHub sign-in. |
-| Static site | Astro + Starlight | Fast, Markdown-friendly, good SEO. Starlight is purpose-built for docs. |
+| Docs and site | Svelte/SvelteKit + Zuplo | Documentation and product pages live in the SvelteKit app; Zuplo for Cloud API gateway. |
 | Dashboard | SvelteKit | Matches SOPHIA's stack. SSR for auth. Svelte for interactive UI. |
 | Static hosting | Cloudflare Pages | Free tier, global CDN, fast deploys from GitHub. |
 | Product analytics | PostHog | Already configured for SOPHIA. Generous free tier. Open-source. |
@@ -97,7 +108,7 @@ This build pack contains everything needed to take Restormel Keys from concept t
 | `.github/workflows/deploy.yml` | `.github/workflows/deploy.yml` | Copy. Replace service names, image names, path filters. Remove SurrealDB and ingestion job steps. |
 | `infra/index.ts` | `infra/index.ts` | Copy and simplify. Remove SurrealDB, VPC connector, ingestion job. Keep Cloud Run, load balancer, SSL, Artifact Registry, Secret Manager. Custom domain: see `docs/domain-mapping-restormel-dev.md`. |
 | `Dockerfile.dashboard` | (repo root) | SvelteKit dashboard (apps/dashboard) for Cloud Run. CI deploys this to keys-dashboard. |
-| `Dockerfile.site` | (repo root) | Astro site (apps/site) for Cloud Run; use Cloudflare Pages for production (see phase-3-deployment). |
+| `Dockerfile.site` | (repo root) | SvelteKit app (dashboard + docs) for Cloud Run; see phase-3-deployment for hosting. |
 
 ### Operational runbooks
 

--- a/docs/03-infrastructure-and-billing.md
+++ b/docs/03-infrastructure-and-billing.md
@@ -19,7 +19,7 @@ Allotment-Technology-Ltd/restormel-keys
 │   ├── react/                 # @restormel/keys-react
 │   └── cli/                   # @restormel/keys-cli
 ├── apps/
-│   ├── site/                  # Astro marketing + Starlight docs
+│   ├── site/                  # SvelteKit app (dashboard + docs + marketing)
 │   ├── dashboard/             # SvelteKit authenticated dashboard
 │   ├── demo-next/             # Next.js App Router demo
 │   └── demo-svelte/           # SvelteKit demo

--- a/docs/04-design-and-site.md
+++ b/docs/04-design-and-site.md
@@ -62,7 +62,7 @@ Embeddable components use **`--rk-*`** for host-app theming (see packages/svelte
 
 ---
 
-## 4. Documentation site (Starlight)
+## 4. Documentation site (Svelte)
 
 P0 pages: Quickstart, Next.js guide, React guide, SvelteKit guide, API reference, Configuration reference, Provider reference, Storage adapters, Security model.
 
@@ -91,7 +91,7 @@ restormel.dev (Cloudflare Pages)
 ├── /                    static homepage
 ├── /keys                static landing page
 ├── /keys/pricing        static + Paddle.js
-├── /keys/docs/*         static docs (Starlight)
+├── /keys/docs/*         docs (Svelte routes)
 └── /keys/dashboard/*    reverse-proxy → Cloud Run
 
 keys-dashboard.europe-west2.run.app (Cloud Run)

--- a/docs/06-roadmap-and-launch.md
+++ b/docs/06-roadmap-and-launch.md
@@ -18,7 +18,7 @@ Svelte components (KeyManager, ModelSelector, CostEstimator). Theming. Web Compo
 
 ### Phase 3: Site + dashboard + billing (Weeks 5–7)
 
-Landing page (Astro). Docs (Starlight). Dashboard (SvelteKit). Paddle billing (from SOPHIA). Zuplo gateway. PostHog analytics. Cloud API. Cloud deployment (Cloud Run + Cloudflare Pages).
+Landing page, docs, and dashboard (Svelte/SvelteKit). Paddle billing (from SOPHIA). Zuplo gateway. PostHog analytics. Cloud API. Cloud deployment (Cloud Run + Cloudflare Pages).
 
 **Gate:** Landing page live. Dashboard handles CRUD + billing. Zuplo portal accessible.
 

--- a/docs/documentation-strategy.md
+++ b/docs/documentation-strategy.md
@@ -28,7 +28,7 @@ Use these in: in-app nav, footer, docs sidebar, runbooks (e.g. zuplo-setup.md, z
 - **Structure:** Consistent heading hierarchy (e.g. H1 → H2 → H3), predictable section patterns, and canonical file paths so agents can resolve references.
 - **Naming:** Same product terms everywhere: Workspace, Project, Environment, Gateway Key, Provider credential, Provider integration, Route, Models, Analytics, Logs & Traces, Dashboard, Sign in, Cloud API, Zuplo gateway, backend key (Gateway Key), consumer key.
 - **Cross-references:** Use stable paths or anchors; avoid duplicate or contradictory truths. One canonical source per topic (see [.cursor/rules/01-doc-governance.mdc](../.cursor/rules/01-doc-governance.mdc)).
-- **Runbooks:** Use the same terminology and link to dashboard/docs with the compulsory URLs. Ensure runbooks are discoverable from the main doc index and Starlight so “Cloud API” and “gateway setup” feel part of the same journey.
+- **Runbooks:** Use the same terminology and link to dashboard/docs with the compulsory URLs. Ensure runbooks are discoverable from the main doc index and the Svelte docs so “Cloud API” and “gateway setup” feel part of the same journey.
 
 ## 4. Where things live
 
@@ -39,7 +39,7 @@ Use these in: in-app nav, footer, docs sidebar, runbooks (e.g. zuplo-setup.md, z
 | Reference           | `docs/reference/`, `docs/api/` | Deployment, extraction, OpenAPI, prompt packs. **Implemented behaviour:** [docs/reference/implemented-behaviour.md](reference/implemented-behaviour.md) — what is live in the dashboard and product so docs do not contradict. **Remaining backlog:** [docs/reference/remaining-backlog-after-implementation.md](reference/remaining-backlog-after-implementation.md) — completed vs partial vs missing, tech debt, next tasks (grounded in repo state). |
 | Design system       | `docs/design-system-index.md`, `docs/design-tokens.css` | Tokens, brand, components. |
 
-Starlight sidebar includes a **Product** group with Dashboard and Sign in links. The Cloud API doc links to the Developer Portal and to the dashboard; runbooks link to the dashboard and Sign in with the canonical URLs above.
+The docs sidebar (Svelte app) includes a **Product** group with Dashboard and Sign in links. The Cloud API doc links to the Developer Portal and to the dashboard; runbooks link to the dashboard and Sign in with the canonical URLs above.
 
 ## 5. Maintenance
 

--- a/docs/reference/extraction-vercel.md
+++ b/docs/reference/extraction-vercel.md
@@ -32,6 +32,8 @@ No Cloud Run, Artifact Registry, Firebase, or GCP Secret Manager is required for
 
 **Vercel:** Add custom domain **restormel.dev**. **NEON_AUTH_BASE_URL** = `https://restormel.dev`; GitHub OAuth callback = `https://restormel.dev/keys/dashboard/api/auth/callback/github`.
 
+**Verified working (Mar 2026):** Root Directory = `.`, Build Command override = `pnpm --filter dashboard build`, Output Directory override = **ON** with value **empty** (so Vercel uses Build Output API from `.vercel/output`). Copy script `scripts/vercel-copy-build-output.mjs` runs as part of dashboard build and copies `apps/dashboard/.vercel/output` to repo root.
+
 ## 404 on every path (restormel.dev)
 
 If **all** routes (/, /favicon.ico, /keys/dashboard) return 404:
@@ -52,11 +54,11 @@ The browser messages *"Event handler must be added on initial evaluation"* and *
 If the deploy log shows **Running "vercel build"** and the build completes in a few hundred ms, Vercel is **ignoring** `vercel.json` and using the default CLI build. Override in the dashboard:
 
 1. **Vercel** → **restormel-keys** → **Settings** → **Build and Deployment**.
-2. Turn **on** the **Override** for **Build Command**.
-3. Set **Build Command** to: **`pnpm --filter dashboard build`**
+2. Turn **on** the **Override** for **Build Command**; set to **`pnpm --filter dashboard build`**.
+3. Turn **on** the **Override** for **Output Directory** and leave the value **empty** (clear any `public` or other path) so Vercel uses the Build Output API.
 4. Save and **Redeploy**.
 
-With that override, the real SvelteKit build runs (~60s), the copy script puts `.vercel/output` at repo root, and the site should serve. Alternatively use **Root Directory = apps/dashboard** (see below) so the build runs from the app folder and no copy is needed.
+With that, the real SvelteKit build runs (~60s), the copy script puts `.vercel/output` at repo root, and the site should serve. Alternatively use **Root Directory = apps/dashboard** (see below) so the build runs from the app folder and no copy is needed.
 
 ### If still 404: switch to Root Directory = `apps/dashboard`
 

--- a/docs/reference/phase-3-deployment.md
+++ b/docs/reference/phase-3-deployment.md
@@ -2,7 +2,7 @@
 
 **Current deployment:** Site and dashboard run on **Vercel** only. No Cloudflare or GCP Cloud Run.
 
-- **Site** (Astro): Vercel project, Root `apps/site`, custom domain **restormel.dev**. Redirects `/keys/dashboard` and `/keys/dashboard/*` to the dashboard.
+- **Site** (SvelteKit): Dashboard and docs in one app; deploy per runbook. Custom domain **restormel.dev**. Dashboard at `/keys/dashboard`, docs at `/keys/docs`.
 - **Dashboard** (SvelteKit): Vercel project, Root `.`, custom domain **restormel.dev/keys/dashboard**. Served at root (no path prefix).
 
 **Gate:** All surfaces accessible (landing, docs, dashboard at restormel.dev/keys/dashboard, Paddle checkout, Zuplo gateway when applicable).
@@ -86,7 +86,7 @@ In the **Paddle dashboard** (sandbox or production):
 
 ## 3. Site → Vercel (current)
 
-The marketing site and Keys docs (`apps/site`, Astro + Starlight) are deployed to **Vercel**. Create a Vercel project with Root Directory **apps/site**; add custom domain **restormel.dev**. The site’s `vercel.json` redirects `/keys/dashboard` and `/keys/dashboard/*` to **https://restormel.dev/keys/dashboard**.
+The marketing site and Keys docs are served by the SvelteKit app (dashboard + docs); deploy per phase-3 runbooks. Create a Vercel project with Root Directory **apps/site**; add custom domain **restormel.dev**. The site’s `vercel.json` redirects `/keys/dashboard` and `/keys/dashboard/*` to **https://restormel.dev/keys/dashboard**.
 
 ### 3.1 (Historical) Site → Cloudflare Pages
 
@@ -250,7 +250,7 @@ After deployment and DNS/proxy are in place:
 | Check | Expected |
 |-------|----------|
 | **Landing** | `https://restormel.dev` (or your domain) serves the marketing homepage. |
-| **Docs** | `https://restormel.dev/keys/docs/` (or equivalent) serves Starlight docs. |
+| **Docs** | `https://restormel.dev/keys/docs/` (or equivalent) serves Svelte docs. |
 | **Dashboard** | `https://restormel.dev/keys/dashboard` loads the SvelteKit app; login and shell work. |
 | **Paddle checkout** | From `/keys/pricing`, “Subscribe” opens Paddle checkout; success redirects to dashboard with `?billing=success` (or configured path). |
 | **Zuplo gateway** | If Phase 3 includes Zuplo, external calls through Zuplo to the Cloud Run API work and developer portal shows docs. |

--- a/docs/reference/restormel-repo-audit-and-gap-analysis.md
+++ b/docs/reference/restormel-repo-audit-and-gap-analysis.md
@@ -16,7 +16,7 @@
 | **Data** | Neon Postgres. Migrations: `001_initial.sql` (projects, api_keys), `002_better_auth.sql` (user, session, account, verification). **Note:** `neon.ts` references a `users` table (upsertUser) that is not created in 001/002 — schema drift or missing migration. |
 | **Auth** | Better Auth with Neon Auth; GitHub sign-in; session in DB. No Management Keys / PATs. |
 | **Gateway** | Zuplo: consumer keys (`zpka_...`) at edge; backend key (`rk_...`) injected to dashboard API. Runbooks in `docs/runbooks/zuplo-*`. |
-| **Site** | Astro + Starlight in `apps/site` (marketing + docs at `/keys/docs/*`). |
+| **Site** | Svelte/SvelteKit app (dashboard + docs at `/keys/docs/*`). |
 | **Embeddable** | `@restormel/keys-svelte` (KeyManager, ModelSelector, CostEstimator), `@restormel/keys-elements`, `@restormel/keys-react`. Demos: demo-next, demo-svelte. |
 
 ---
@@ -126,7 +126,7 @@ restormel-keys/
 │   │   └── src/routes/api/ # projects, projects/[id], projects/[id]/keys, auth/*, health, billing/*
 │   ├── demo-next/          # Next.js demo; KeyManager, settings, API keys
 │   ├── demo-svelte/        # SvelteKit demo; KeyManager, settings
-│   └── site/               # Astro + Starlight; marketing + /keys/docs/*
+│   └── dashboard/          # SvelteKit; dashboard + /keys/docs/*
 ├── packages/
 │   ├── core/               # @restormel/keys — keys, router, providers, cost, entitlements, wallet
 │   │   ├── src/            # types.ts, keys.ts, router.ts, providers/*, server/*, storage/*

--- a/docs/reference/sophia-dogfooding-plan.md
+++ b/docs/reference/sophia-dogfooding-plan.md
@@ -1,0 +1,165 @@
+# SOPHIA dogfooding plan: Restormel Keys as primary test
+
+**Status:** Reference (plan). Work is performed **in the SOPHIA repo** and in Restormel dashboard/API configuration. This doc defines the scope and mapping so dogfooding doubles as the best test of Restormel Keys.
+
+**Goal:** SOPHIA uses Restormel Keys for (1) the **ingestion pipeline** with fallback routes and policies, and (2) **embedded UI** so end-users can select which models to use for philosophy queries.
+
+---
+
+## Scope
+
+| Area | What SOPHIA needs | What Restormel Keys provides |
+|------|-------------------|------------------------------|
+| **Ingestion pipeline** | All ingestion AI calls go through Restormel Keys: resolution, provider/model choice, fallback when a provider fails or is rate-limited. | Dashboard: **Workspace → Project → Environment → Route → Steps**. Routes have **route mode** (e.g. fallback chain), **steps** (provider + model + fallback behaviour). **Resolve API** returns route + provider + model for a request. **Policies** (model allowlist/denylist, budget cap, deprecated-model block) apply at project/environment/route. |
+| **Fallback routes and policies** | Configurable fallback order (e.g. OpenAI → Anthropic → Google) and policy guards (allowed models, budget, deprecated blocking). | **Routes**: `routeMode` (e.g. `fallback_chain`), steps with `providerPreference`, `modelId`, `fallbackOn`. **Policies**: created per workspace/project/environment; types include `model_allowlist`, `model_denylist`, `deprecated_model_block`, `budget_cap`, `token_cap`. **Evaluate API** for testing policy outcome for a context. |
+| **End-user model selection** | Philosophy query UI lets users pick which model(s) to use. Selection must be consistent with routes and policies (e.g. only show allowed models). | **Embeddable UI**: `KeyManager`, **ModelSelector**, `CostEstimator` from `@restormel/keys-svelte` or `@restormel/keys-react`. Host app points them at Restormel Keys API (or a SOPHIA proxy that calls Restormel). Model list can be driven by dashboard **model catalog** and **policies** so only valid choices are shown. |
+
+---
+
+## Step 0: Remove SOPHIA custom routing and model selection (first step)
+
+Before wiring Restormel Keys into ingestion and UI, SOPHIA’s **custom** routing and model-selection layer must be removed or retired so there is a single source of truth (Restormel).
+
+**Remove or replace in SOPHIA:**
+
+| What | Action |
+|------|--------|
+| Custom provider/model selection logic | Delete or retire internal modules that choose provider/model (custom router, fallback chains, provider health checks, bespoke model allowlists). Replace with a single “call Restormel resolve” step before each AI request. |
+| Custom model picker UI | Remove UI that presents model choice using SOPHIA-specific logic/data. Replace with Restormel’s embeddable **ModelSelector** (see §3). |
+| Custom BYOK settings panel | If it duplicates KeyManager/ModelSelector, remove or replace with Restormel’s **KeyManager** (or defer BYOK to a later step). |
+
+**Keep in SOPHIA (do not delete):**
+
+- Billing, wallet, top-ups, founder logic.
+- Auth/session model (reuse for API auth).
+- Ingestion pipeline **orchestration** (jobs/workers); only the “how we choose model/provider” is replaced.
+
+**Outcome:** One source of truth for routing and fallback (Restormel routes/steps). No custom “choose provider/model” logic in the ingestion path. Model selection in the product UI is done via Restormel ModelSelector (or a thin wrapper).
+
+A full **build-agent prompt** for the SOPHIA repo is in [§ Build-agent prompt (SOPHIA repo)](#build-agent-prompt-sophia-repo) below; use it in the SOPHIA project to perform Step 0 and the replacement work.
+
+---
+
+## 1. Ingestion pipeline on Restormel Keys
+
+- **Current (SOPHIA):** Ingestion likely uses platform keys and/or ad-hoc routing. Goal is to route all ingestion through Restormel so resolution, fallback, and policies are centralized.
+- **Restormel side:**
+  - Create (or reuse) a **workspace** and **project** for SOPHIA ingestion.
+  - Define **environments** (e.g. production, staging).
+  - Create **routes** with **steps** that define provider order and optional model pinning; set **route mode** to fallback chain so failed steps trigger the next step.
+  - Attach **policies** as needed (model allowlist, budget cap, deprecated-model block).
+  - **Resolve API:** `POST /keys/dashboard/api/projects/[id]/resolve` (or equivalent gateway-backed API) with `environmentId` (and optional `routeId`) returns `routeId`, `providerType`, `modelId`, etc. SOPHIA ingestion calls this before each AI request and uses the returned provider/model (and gateway key) to call the provider or a Restormel proxy.
+- **SOPHIA side (in SOPHIA repo):**
+  - Add a **resolve** step to the ingestion path: call Restormel resolve API with project + environment (and optionally route), then use the returned provider/model and credential (platform or BYOK) for the upstream request.
+  - Use **Gateway Key** (or Management Key) for authenticating to Restormel; store in SOPHIA env or secret manager.
+  - On resolve failure or 503, implement local fallback (e.g. retry, skip step) as needed.
+
+**Reference:** Dashboard route resolver: `apps/dashboard/src/lib/server/route-resolver.ts`. Resolve endpoint: `apps/dashboard/src/routes/keys/dashboard/api/projects/[id]/resolve/+server.ts`. Zuplo/API gateway runbooks: `docs/runbooks/zuplo-setup.md`, `docs/runbooks/zuplo-launch-cli.md`.
+
+---
+
+## 2. Fallback routes and policies
+
+- **Routes:** In Restormel dashboard, configure routes with multiple **steps**. Each step has provider preference and optional model; `routeMode` “fallback chain” means if a step fails (e.g. rate limit, timeout), the next step is used. Steps and route mode are editable in the UI (Routes → route → Fallback / steps).
+- **Policies:** Create policies at workspace/project/environment level. Policy types include `model_allowlist`, `model_denylist`, `provider_allowlist`, `provider_denylist`, `deprecated_model_block`, `budget_cap`, `token_cap`. Policy evaluation is used when resolving or when checking if a user choice is allowed.
+- **SOPHIA:** No code change to “what” fallback means; Restormel owns the chain. SOPHIA just calls resolve and uses the result. For **end-user** model choice (see below), SOPHIA may need to call an API that returns “allowed models for this context” (derived from catalog + policies) so the embedded ModelSelector only shows valid options.
+
+**Reference:** Policies: `apps/dashboard/src/routes/keys/dashboard/api/policies/`, evaluate: `.../api/policies/evaluate/+server.ts`. Route steps and route mode: `apps/dashboard/src/routes/keys/dashboard/projects/[id]/routes/[routeId]/+page.svelte`, `.../api/projects/[id]/routes/[routeId]/+server.ts`.
+
+---
+
+## 3. UI embedding for end-user model selection
+
+- **Goal:** In SOPHIA, end-users (philosophy query users) can choose which model to use. That choice should be constrained by Restormel routes/policies and reflect the same model catalog and lifecycle (e.g. deprecation warnings).
+- **Restormel side:**
+  - **Model catalog** and **policies** define which models are available and allowed. Expose a small API or use existing “list models” + “evaluate policy” so a host app can request “allowed models for this project/environment (and optionally route).”
+  - **Embeddable components:** `KeyManager` (provider credentials), **ModelSelector** (pick model; can be filtered by allowed list). From `@restormel/keys-svelte` or `@restormel/keys-react`; or Web Components from `@restormel/keys-elements`. Host app provides API base URL (Restormel dashboard API or SOPHIA proxy), `userId`, and optional theme.
+- **SOPHIA side:**
+  - Embed **ModelSelector** (and optionally KeyManager) in the philosophy query UI (e.g. settings or query form).
+  - Point the components at an API that backs Restormel (dashboard API with auth, or a SOPHIA route that proxies to Restormel and adds session/auth). Optionally, SOPHIA fetches “allowed models” once and passes them into ModelSelector so only valid options are shown.
+  - On “run philosophy query,” send the selected model (and any route/environment context) so the server can call Restormel resolve (or use the same route) and then run the query with the resolved provider/model.
+
+**Reference:** Embedding: `packages/svelte` (KeyManager, ModelSelector, CostEstimator), `packages/react` (KeysProvider, KeyManager, ModelSelector, hooks), `packages/elements` (Web Components). Docs: `apps/dashboard/src/routes/keys/docs/compatibility/+page.svelte`, `docs/02-architecture.md`, `docs/01-product-strategy.md` (Mode 2 / Mode 3). BYOK/adapter runbook: `docs/reference/sophia-integration.md`.
+
+---
+
+## 4. Relationship to existing SOPHIA integration runbook
+
+- **sophia-integration.md** covers replacing SOPHIA’s **inline BYOK** with `@restormel/keys`: key storage, Keys middleware, resolve middleware, and refactoring BYOK routes. That remains the basis for **end-user provider credentials** (KeyManager) and server-side resolution when using user keys.
+- **This dogfooding plan** adds:
+  - **Ingestion pipeline** using Restormel for all ingestion AI calls (platform keys + fallback routes and policies).
+  - **Explicit use of routes and policies** in the dashboard, with resolve API as the single place for “which provider/model for this request.”
+  - **ModelSelector embedding** so end-users choose models for philosophy queries within Restormel’s catalog and policy constraints.
+
+Implement in this order (or in parallel with clear handoffs): **(0) Remove SOPHIA custom routing/model selection** (see Step 0 and build-agent prompt); (1) ingestion pipeline + resolve API + fallback routes in dashboard; (2) policies as needed; (3) BYOK/adapter per sophia-integration.md if not already done; (4) embedded ModelSelector (and optional KeyManager) in SOPHIA, backed by Restormel API or SOPHIA proxy.
+
+---
+
+## 5. Success criteria (dogfooding as test)
+
+- **Ingestion:** All SOPHIA ingestion AI requests go through Restormel resolve; fallback behaviour is configured in dashboard routes and observed in practice (e.g. step failure → next step).
+- **Policies:** At least one policy type (e.g. model allowlist or deprecated_model_block) is configured and affects resolution or allowed model list in SOPHIA.
+- **UI:** End-users can select the model for philosophy queries via the embedded ModelSelector; selection is consistent with Restormel routes/policies and catalog.
+
+This gives Restormel Keys a single, real-world test: SOPHIA as the first consumer of the full stack (control plane, resolve, fallback, policies, embeddable UI).
+
+---
+
+## Build-agent prompt (SOPHIA repo)
+
+Use the following prompt in the **SOPHIA** project (build agent / Cursor) to perform Step 0 and the replacement work. It is self-contained with Restormel context.
+
+<!-- BEGIN BUILD-AGENT PROMPT - copy from here -->
+
+You are working in the SOPHIA repo. Goal: dogfood Restormel Keys end-to-end by **removing SOPHIA's custom AI routing/model selection/BYOK UI** and replacing it with Restormel Keys control-plane (routes/policies/resolve) + embeddable UI (ModelSelector, optionally KeyManager).
+
+### Context (Restormel Keys)
+
+- Restormel dashboard is live at `https://restormel.dev/keys/dashboard`.
+- Restormel supports:
+  - **Routes** with **steps** (provider preference + optional model) and route-mode `fallback_chain`.
+  - **Policies** (model allowlist/denylist, provider allowlist/denylist, deprecated_model_block, budget_cap, token_cap, etc.).
+  - A **resolve endpoint** that returns the chosen provider/model for a request:
+    - `POST https://restormel.dev/keys/dashboard/api/projects/[id]/resolve` with body `{ environmentId?, routeId? }`. Auth: Bearer with Restormel Gateway Key.
+- Embeddable UI packages:
+  - `@restormel/keys-react` (React): `KeysProvider`, `ModelSelector`, `KeyManager`, `CostEstimator`.
+  - `@restormel/keys-elements` (Web Components).
+- Integration runbook in restormel-keys repo: `docs/reference/sophia-integration.md` (KeyStorage adapter + middleware; **no secrets committed**).
+- Dogfooding plan: `docs/reference/sophia-dogfooding-plan.md` in restormel-keys.
+
+### What to remove/replace in SOPHIA (first step)
+
+- **Remove:** Internal modules that select models/providers directly (custom router, fallback chains, provider health checks, bespoke model allowlists). Any UI that presents model choice using SOPHIA-specific logic. Any custom BYOK settings panel that duplicates KeyManager/ModelSelector.
+- **Keep:** Billing/wallet/top-ups/founder logic. Auth/session model. Ingestion pipeline orchestration (jobs/workers); replace only *how* model/provider is chosen.
+
+### Replacement architecture in SOPHIA
+
+**A) Ingestion pipeline (platform-side)**  
+- Add a server module (e.g. `src/lib/server/restormel-keys.ts`) that calls Restormel resolve before each ingestion AI call and uses the returned provider/model. Use env: `RESTORMEL_GATEWAY_KEY`, `RESTORMEL_PROJECT_ID`, `RESTORMEL_ENVIRONMENT_ID`, optional `RESTORMEL_ROUTE_ID`. Do not commit secrets; document placeholders only.
+
+**B) End-user model selection**  
+- Replace SOPHIA's model picker with Restormel's **ModelSelector** (`@restormel/keys-react` if React/Next). Only show models allowed for the context (from Restormel catalog/policies or a SOPHIA proxy). On "run philosophy query," pass selected model (and route/environment context) so server calls Restormel resolve and runs the request.
+
+**C) BYOK (optional in step 1)**  
+- If SOPHIA has end-user BYOK: follow `docs/reference/sophia-integration.md` for KeyStorage and key CRUD with `@restormel/keys`; do not change API contracts; do not log raw keys. If not needed for first milestone, skip KeyManager and only embed ModelSelector + server-side resolve.
+
+### Concrete tasks
+
+1. **Inventory** SOPHIA: list files/modules for (a) provider routing/fallback, (b) model selection, (c) BYOK UI. Decide: delete, deprecate behind flag, or replace in-place.
+2. **Implement** a minimal typed client that calls Restormel resolve (with validation; no keys in errors).
+3. **Replace** ingestion selection: before each AI call, call resolve with env+route; use returned provider/model; remove custom fallback logic.
+4. **Replace** UI: swap model dropdown/selector with `ModelSelector`; preserve loading/error/empty and accessibility.
+5. **Tests:** Update tests for new selection source; add integration test that mocks Restormel resolve and asserts correct provider/model.
+6. **Secrets:** Document env placeholders only; no real values committed.
+
+### Acceptance criteria
+
+- **One** source of truth for routing and fallback: Restormel routes/steps.
+- No custom "choose provider/model" logic in the ingestion path.
+- Product UI uses Restormel ModelSelector (or thin wrapper) for end-user model selection.
+- No unintentional API contract breaks (especially BYOK if present).
+- No raw keys in logs, errors, tests, or docs.
+
+If the browser needs model/list data, expose a SOPHIA proxy that uses SOPHIA auth and never exposes gateway keys client-side.
+
+<!-- END BUILD-AGENT PROMPT -->

--- a/docs/reference/sophia-integration.md
+++ b/docs/reference/sophia-integration.md
@@ -188,3 +188,9 @@ export function createResolveHandler(storage: KeyStorage) {
 
 - **SOPHIA tests pass.**
 - **BYOK works end-to-end.**
+
+---
+
+## See also
+
+- **SOPHIA dogfooding plan** — [sophia-dogfooding-plan.md](sophia-dogfooding-plan.md): using Restormel Keys for the **ingestion pipeline** (fallback routes and policies) and **embedded UI** (ModelSelector) so end-users can select models for philosophy queries. That plan extends this runbook with ingestion + resolve API + policies + embeddable model selection.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -9,3 +9,5 @@ What is verified when. **Single source** for verification scope; scripts are in 
 **Later:** E2E, browser matrix, bundle/performance budgets, dashboard/billing tests, observability.
 
 **Scripts:** review-docs.sh, check-secrets.sh, check-repo-hygiene.sh, check-dependency-policy.sh (see bootstrap-plan).
+
+**Run locally (coding quality):** From repo root, `pnpm run quality` runs dashboard typecheck (svelte-check), dashboard build, dashboard unit tests, review-docs, check-secrets, and repo hygiene. Use this before committing to catch Svelte parse/type errors, build failures, and doc/secret/hygiene issues. Optional: `RUN_SMOKE=1 pnpm run quality` also smoke-tests key docs routes (preview server + GET); or run `pnpm run smoke:dashboard` after a build to verify docs pages return 2xx (catches runtime errors like undefined refs in templates). `pnpm run check:dashboard` runs only dashboard check + build.

--- a/docs/ux-contracts.md
+++ b/docs/ux-contracts.md
@@ -89,9 +89,9 @@ Apply this pattern on all dashboard pages (Overview, Projects, Billing, Settings
 
 ## 5. Application
 
-- **Site (Astro):** MarketingLayout nav and footer use the navigation model and canonical URLs. Section pattern: `.section-title` + `.section-intro` + content. Pricing and docs use the same links and copy conventions.
+- **Site (Svelte/SvelteKit):** Nav and footer use the navigation model and canonical URLs. Section pattern: `.section-title` + `.section-intro` + content. Pricing and docs use the same links and copy conventions.
 - **Dashboard (SvelteKit):** Layout and routes use the same URLs; welcome and error blocks use state conventions and copy registry terms. Section pattern: `.page-title` + `.page-desc` (and `.section-title` + `.section-desc` for sub-sections) with tokenized spacing.
-- **Docs (Starlight):** Sidebar and content use Dashboard/Sign in links and product nouns from the registry.
+- **Docs (Svelte):** Sidebar and content use Dashboard/Sign in links and product nouns from the registry.
 - **Embeddable components:** KeyManager and other embeddables use the same security/key copy and state patterns (loading/error/empty/success) where applicable.
 
 When adding or changing copy or nav, check this document and [documentation-strategy.md](documentation-strategy.md) for consistency.

--- a/docs/walkthrough/00-index.md
+++ b/docs/walkthrough/00-index.md
@@ -1,0 +1,135 @@
+# Walkthrough — Master Index
+
+> **Status:** Proposed. Entry point for the `docs/walkthrough/` folder. Commit this file last after all other walkthrough files are in place.
+
+---
+
+## What this is
+
+A public-facing, app-agnostic integration walkthrough for Restormel Keys. It takes a developer from "I have an AI app with some routing" to "my app resolves, routes, enforces policies, and shows embeddable UI through Restormel Keys."
+
+The walkthrough is designed to work as:
+- **Public docs** (Svelte/SvelteKit docs under `/keys/docs/walkthrough/`, served by the same app as the dashboard)
+- **A dogfooding plan** (the same journey SOPHIA follows as the first consumer)
+- **A prompt pack** (12 build-agent prompts that a coding agent can execute sequentially)
+
+---
+
+## File listing
+
+| File | Purpose | Type |
+|------|---------|------|
+| `00-index.md` | **This file.** Master index and reading order. | Index |
+| `00-walkthrough-ia.md` | Docs IA: navigation placement, page map, mermaid flow diagram, cross-links, dashboard checklist integration. | Architecture |
+| `01-writing-style-guide.md` | Terminology, voice, page template, callout types, code conventions, prompt formatting rules. | Style guide |
+| `02-phase-0-inventory.md` | **Phase 0.** "Before you begin" entry page + audit existing routing. Prompts: P01, P02. | Walkthrough page |
+| `03-phase-1-install.md` | **Phase 1.** Install packages, create dashboard project, generate Gateway Key, run `keys doctor`. Prompt: P03. | Walkthrough page |
+| `04-phase-2-resolve.md` | **Phase 2.** First resolve call (curl + typed client), feature flag wiring, error handling, optional local resolve. Prompts: P04, P05. | Walkthrough page |
+| `05-phase-3-routes.md` | **Phase 3.** Create routes with steps, configure fallback chain, test failover, wire route IDs. Prompt: P06. | Walkthrough page |
+| `06-phase-4-policies.md` | **Phase 4.** Model allowlist, deprecated-model block, budget cap, evaluate endpoint, policy error handling. Prompt: P07. | Walkthrough page |
+| `07-phase-5-ui.md` | **Phase 5.** Embed ModelSelector (React, SvelteKit, Web Components), optional KeyManager, policy-filtered model list, theming. Prompt: P08. | Walkthrough page |
+| `08-phase-6-golive.md` | **Phase 6.** Pre-cutover checklist, parallel run, full cutover, smoke test, legacy code removal. Prompts: P09, P10. | Walkthrough page |
+| `09-migration-paths.md` | Migration variants: custom, LiteLLM, Portkey, OpenRouter. Strangler pattern. Comparison table. Prompt: P11. | Migration guide |
+| `10-verification-strategy.md` | Dashboard checks, CLI checks, smoke tests, ongoing monitoring, CI integration. Prompt: P12. | Verification |
+| `11-prompt-index.md` | All 12 build-agent prompts collected with context doc references and execution order. | Prompt pack |
+
+---
+
+## Reading order
+
+**For docs readers (understanding the product):**
+
+```
+00-walkthrough-ia.md → 02-phase-0 → 03-phase-1 → 04-phase-2 → 05-phase-3 →
+06-phase-4 → 07-phase-5 → 08-phase-6 → 09-migration-paths → 10-verification
+```
+
+**For implementors (executing with a coding agent):**
+
+```
+01-writing-style-guide.md (skim for terminology) → 11-prompt-index.md (execute P01–P12 in order)
+```
+
+**For docs authors (contributing to the walkthrough):**
+
+```
+00-walkthrough-ia.md → 01-writing-style-guide.md → then the page you're editing
+```
+
+---
+
+## Cross-references to existing repo docs
+
+The walkthrough references these existing docs. Keep links consistent when file paths change.
+
+### Strategy and architecture
+
+| Existing doc | Referenced by | Why |
+|-------------|---------------|-----|
+| `docs/01-product-strategy.md` | Migration paths, Phase 4 | Product modes, competitive gap matrix |
+| `docs/02-architecture.md` | Phases 1–5, prompt index | Package structure, framework compatibility |
+| `docs/ux-contracts.md` | Phase 1, Phase 5, style guide | Canonical URLs, state conventions |
+| `docs/documentation-strategy.md` | IA doc | Same-link rule, doc journey |
+
+### Reference and runbooks
+
+| Existing doc | Referenced by | Why |
+|-------------|---------------|-----|
+| `docs/reference/sophia-dogfooding-plan.md` | Phases 0–5, prompt index | Removal pattern, resolve wiring, routes, policies, UI |
+| `docs/reference/sophia-integration.md` | Phases 0, 2, 5, prompt index | KeyStorage adapter, resolve handler, middleware |
+| `docs/runbooks/zuplo-setup.md` | Phase 6 | Gateway validation checks |
+| `docs/testing-strategy.md` | Verification strategy | Testing scope |
+
+### Source code
+
+| File | Referenced by | Why |
+|------|---------------|-----|
+| `packages/core/src/keys.ts` | Phases 1–2 | `createKeys` API |
+| `packages/core/src/router.ts` | Phases 2–3 | Router, `ResolveResult`, fallback |
+| `packages/core/src/server/resolve.ts` | Phase 2 | Resolve middleware |
+| `packages/core/src/entitlements.ts` | Phase 4 | Entitlements, model matching |
+| `packages/cli/README.md` | Phases 1, 6, verification | CLI commands |
+| `packages/react/README.md` | Phase 5 | React wrapper API |
+| `packages/elements/README.md` | Phase 5 | Web Component API |
+| `apps/dashboard/…/resolve/+server.ts` | Phases 2–3 | Resolve endpoint |
+| `apps/dashboard/…/policies/evaluate/+server.ts` | Phase 4 | Evaluate endpoint |
+| `.github/workflows/ci.yml` | Verification | CI workflow |
+
+---
+
+## Prompt summary
+
+12 prompts covering the full integration lifecycle:
+
+| Phase | Prompts | Focus |
+|-------|---------|-------|
+| 0 — Inventory | P01, P02 | Audit, classify, feature flag |
+| 1 — Install | P03 | Packages, config, env |
+| 2 — Resolve | P04, P05 | HTTP client, local resolve |
+| 3 — Routes | P06 | Route IDs, call sites |
+| 4 — Policies | P07 | Policy error handling |
+| 5 — UI | P08 | Embed components |
+| 6 — Go live | P09, P10 | Smoke test, legacy removal |
+| Migration | P11 | LiteLLM plan |
+| Ongoing | P12 | CI verification |
+
+**Fresh integration:** `P01 → P02 → P03 → P04 → P06 → P07 → P08 → P09 → [cutover] → P10 → P12`
+
+**LiteLLM migration:** `P11 → P01 → P02 → P03 → P04 → P06 → P07 → P08 → P09 → [cutover] → P10 → P12`
+
+---
+
+## How to commit this folder
+
+Recommended path: `docs/walkthrough/` in the restormel-keys repo.
+
+```bash
+mkdir -p docs/walkthrough
+# Copy all walkthrough files into docs/walkthrough/
+```
+
+Then update `docs/00-master-index.md` to include a "Walkthrough" entry pointing to `docs/walkthrough/00-index.md`.
+
+---
+
+*This completes the walkthrough documentation suite.*

--- a/docs/walkthrough/00-walkthrough-ia.md
+++ b/docs/walkthrough/00-walkthrough-ia.md
@@ -1,0 +1,181 @@
+# Walkthrough — Docs IA and Navigation
+
+> **Status:** Proposed. This document defines the information architecture for the "Walkthrough" section of the Restormel Keys public docs.
+
+---
+
+## 1. Where it sits in the docs
+
+The Walkthrough is a new top-level section sitting between "Start here" (existing conceptual docs) and "Reference" (existing API/CLI/config reference). It is the primary onboarding journey for any developer integrating Restormel Keys into an existing app.
+
+```
+restormel.dev/keys/docs/
+
+Start here                          ← existing
+  Overview
+  Framework compatibility
+  Cloud API
+
+Walkthrough                         ← NEW
+  Before you begin                  ← entry page (prerequisites, what you'll build)
+  Phase 0 — Inventory your routing  ← audit + retire custom routing
+  Phase 1 — Install and configure   ← packages, env, project in dashboard
+  Phase 2 — Resolve your first model← one resolve call, verify it works
+  Phase 3 — Add routes and fallbacks← multi-step routing in dashboard
+  Phase 4 — Apply policies          ← allowlists, deprecation, budgets
+  Phase 5 — Embed the UI            ← ModelSelector, KeyManager in your app
+  Phase 6 — Go live                 ← parallel run, cutover, verify
+  Migration paths                   ← LiteLLM / Portkey / OpenRouter / custom
+
+Reference                           ← existing
+  API reference
+  CLI reference (keys doctor, validate, etc.)
+  Configuration reference
+  Provider reference
+```
+
+### Entry points into the Walkthrough
+
+| Coming from | Lands on | Why |
+|-------------|----------|-----|
+| Docs home ("Get started") | Before you begin | Primary CTA |
+| Framework compatibility page | Phase 1 — Install | "Ready to integrate?" link at bottom |
+| Cloud API page | Phase 2 — Resolve | "Use the resolve endpoint in your app" |
+| Dashboard onboarding checklist | Phase 1 or Phase 3 | Dashboard links into walkthrough steps |
+| Pricing page (post-signup) | Before you begin | "Start integrating" CTA |
+
+### Exit points from the Walkthrough
+
+| Walkthrough page | Links out to |
+|------------------|--------------|
+| Phase 1 | CLI reference (`keys init`, `keys doctor`) |
+| Phase 2 | API reference (resolve endpoint schema) |
+| Phase 3 | Dashboard (Routes UI), Cloud API docs |
+| Phase 4 | Dashboard (Policies UI), API reference (evaluate endpoint) |
+| Phase 5 | Framework compatibility, Component reference (KeyManager, ModelSelector props/events) |
+| Phase 6 | CLI reference (`keys validate`), Dashboard (logs/analytics) |
+| Migration paths | Existing docs for LiteLLM, Portkey, OpenRouter (external links) |
+
+---
+
+## 2. Page map with purposes
+
+| # | Page slug | Page title | Purpose | Estimated length |
+|---|-----------|------------|---------|------------------|
+| 0 | `walkthrough/` | Before you begin | Prerequisites, what you'll build, mental model, key terms | Short (1 screen) |
+| 1 | `walkthrough/phase-0-inventory` | Phase 0 — Inventory your routing | Audit existing custom routing/model selection; decide what to remove, keep, or wrap | Medium |
+| 2 | `walkthrough/phase-1-install` | Phase 1 — Install and configure | Install packages, create project in dashboard, set env vars, run `keys doctor` | Medium |
+| 3 | `walkthrough/phase-2-resolve` | Phase 2 — Resolve your first model | Make one resolve call from your backend, see the result, understand the response | Short–Medium |
+| 4 | `walkthrough/phase-3-routes` | Phase 3 — Add routes and fallbacks | Create a route with steps in the dashboard, configure fallback chain, test failover | Medium |
+| 5 | `walkthrough/phase-4-policies` | Phase 4 — Apply policies | Add model allowlist, deprecated-model block, budget cap; test policy enforcement | Medium |
+| 6 | `walkthrough/phase-5-ui` | Phase 5 — Embed the UI | Add ModelSelector and/or KeyManager to your app; wire events to your backend | Medium |
+| 7 | `walkthrough/phase-6-go-live` | Phase 6 — Go live | Parallel run strategy, traffic shifting, cutover, post-cutover verification | Medium |
+| 8 | `walkthrough/migration-paths` | Migration paths | Strangler patterns for LiteLLM, Portkey, OpenRouter, and custom routing | Medium–Long |
+
+---
+
+## 3. End-to-end flow diagram
+
+```mermaid
+graph LR
+    subgraph "Your app"
+        A["Backend<br/>(API route / server action)"]
+        B["Frontend<br/>(settings page)"]
+    end
+
+    subgraph "Restormel Keys"
+        C["Resolve API<br/>POST /api/projects/[id]/resolve"]
+        D["Routes + Steps<br/>(fallback chain)"]
+        E["Policies<br/>(allowlist, budget, deprecated)"]
+        F["Dashboard<br/>(configure routes, policies, keys)"]
+        G["Embeddable UI<br/>(ModelSelector, KeyManager)"]
+    end
+
+    subgraph "AI Providers"
+        H["OpenAI"]
+        I["Anthropic"]
+        J["Google"]
+    end
+
+    A -->|"1. resolve(env, route)"| C
+    C -->|"evaluate"| D
+    D -->|"check"| E
+    C -->|"2. { provider, model, source }"| A
+    A -->|"3. call provider"| H
+    A -.->|"fallback"| I
+    A -.->|"fallback"| J
+
+    B -->|"embed"| G
+    G -->|"allowed models"| C
+    F -->|"configure"| D
+    F -->|"configure"| E
+```
+
+**Reading the diagram:**
+
+1. Your backend calls the Resolve API before each AI request.
+2. Resolve evaluates the route's steps (fallback chain) against active policies.
+3. You get back a provider, model, and key source — then call the provider directly.
+4. Your frontend embeds ModelSelector (and optionally KeyManager) so users pick models within policy constraints.
+5. Everything is configured in the Dashboard: routes, steps, policies, keys.
+
+---
+
+## 4. Cross-link map (walkthrough ↔ existing docs)
+
+This table ensures every walkthrough page links to (and is linked from) the right existing docs. Use these when writing each page.
+
+| Walkthrough page | Must link TO | Should be linked FROM |
+|------------------|-------------|----------------------|
+| Before you begin | Framework compatibility, CLI reference, Dashboard | Docs home, Pricing, Framework compatibility |
+| Phase 0 | sophia-integration.md (as reference pattern), Dashboard | — |
+| Phase 1 | CLI reference (`keys init`, `keys doctor`), Framework compatibility, Dashboard (create project) | Framework compatibility ("Next: integrate") |
+| Phase 2 | API reference (resolve endpoint), Cloud API, Zuplo setup | Cloud API ("Try resolve in your app") |
+| Phase 3 | Dashboard (Routes UI), API reference (routes schema) | — |
+| Phase 4 | Dashboard (Policies UI), API reference (evaluate endpoint, policy types) | — |
+| Phase 5 | Framework compatibility (package choice), Component reference (props, events, theming) | Framework compatibility ("Embed UI") |
+| Phase 6 | CLI reference (`keys validate`, `keys doctor`), Dashboard (logs) | — |
+| Migration paths | LiteLLM docs (external), Portkey docs (external), OpenRouter docs (external) | — |
+
+---
+
+## 5. Dashboard onboarding checklist integration
+
+The existing dashboard at `restormel.dev/keys/dashboard` has an onboarding checklist. Each checklist item should deep-link into the corresponding walkthrough page:
+
+| Dashboard checklist item | Links to walkthrough page |
+|--------------------------|--------------------------|
+| "Create your first project" | Phase 1 — Install and configure |
+| "Generate an API key" | Phase 1 — Install and configure |
+| "Configure a route" | Phase 3 — Add routes and fallbacks |
+| "Add a policy" | Phase 4 — Apply policies |
+| "Make your first resolve call" | Phase 2 — Resolve your first model |
+| "Embed UI in your app" | Phase 5 — Embed the UI |
+
+---
+
+## 6. Navigation UX notes
+
+- **Progress indicator:** Each walkthrough page should show a lightweight step indicator (e.g. "Step 3 of 8") so the reader knows where they are and how much remains.
+- **Previous / Next:** Every page has prev/next navigation at the bottom pointing to the adjacent walkthrough pages.
+- **"Skip to…":** The entry page ("Before you begin") should have a "Skip to…" section for readers who already have parts done (e.g. "Already installed? Skip to Phase 2").
+- **Time estimates:** Each page should show an estimated time (e.g. "~10 minutes") so readers can plan.
+- **Agent-friendly structure:** Consistent heading hierarchy (H1 = page title, H2 = major sections, H3 = steps) so coding agents can parse walkthrough content reliably.
+
+---
+
+## 7. Relationship to existing docs
+
+This walkthrough does **not** replace existing docs. It is an opinionated, linear path through them:
+
+- **Framework compatibility** remains the reference for "which packages do I install for my stack."
+- **API reference** remains the canonical endpoint/schema documentation.
+- **CLI reference** remains the canonical command documentation.
+- **Cloud API** remains the gateway/Zuplo reference.
+- **sophia-integration.md** and **sophia-dogfooding-plan.md** remain internal reference docs (not linked from public walkthrough, but their patterns inform the walkthrough content).
+
+The walkthrough is the **"happy path"** that stitches these together into a sequential integration journey.
+
+---
+
+*Next file: `01-writing-style-guide.md` — terminology, voice, and formatting conventions for the walkthrough.*

--- a/docs/walkthrough/01-writing-style-guide.md
+++ b/docs/walkthrough/01-writing-style-guide.md
@@ -1,0 +1,244 @@
+# Walkthrough — Writing Style Guide
+
+> **Status:** Proposed. Canonical style rules for the "Walkthrough" section of the Restormel Keys public docs. All walkthrough pages must follow these conventions.
+
+---
+
+## 1. Voice and tone
+
+- **Second person throughout.** "You" and "your app," never "the developer" or "one."
+- **Present tense.** "You see a JSON response" not "You will see a JSON response."
+- **Active voice.** "The resolve endpoint returns…" not "A response is returned by…"
+- **Confident but not cocky.** State what happens; don't hedge with "should" or "might" when describing deterministic behaviour. Use "if" for genuinely conditional outcomes.
+- **Short sentences.** Aim for 15–20 words average. Break complex ideas across multiple sentences rather than using semicolons or dashes.
+- **No filler.** Cut "simply," "just," "easily," "of course," "as you can see." If something is simple, the reader will feel it from the short instructions — you don't need to tell them.
+
+---
+
+## 2. Canonical terminology
+
+Use these terms exactly. Do not invent synonyms in any walkthrough page.
+
+| Term | What it means | Never say instead |
+|------|---------------|-------------------|
+| **Workspace** | Top-level organisational container in the dashboard (maps to an account or org) | "Account," "org," "tenant" |
+| **Project** | A container for routes, policies, keys, and usage within a workspace | "App," "service," "instance" |
+| **Environment** | A deployment context within a project (e.g. production, staging) | "Stage," "slot," "config" |
+| **Gateway Key** | The key your backend uses to authenticate to the Restormel API (format `rk_…`) | "API key" (ambiguous), "backend key," "server key" |
+| **Provider credential** | An AI provider API key stored in Restormel (e.g. an OpenAI key) | "BYOK key," "user key," "secret" |
+| **Route** | A named routing configuration within a project; contains steps and a route mode | "Endpoint," "path," "chain" |
+| **Step** | One entry in a route's fallback chain; specifies a provider preference and optional model | "Stage," "tier," "level" |
+| **Route mode** | How a route's steps are evaluated (e.g. `fallback_chain`) | "Strategy," "algorithm" |
+| **Policy** | A rule that constrains resolution (model allowlist, budget cap, deprecated block, etc.) | "Guard," "filter," "rule" (too vague) |
+| **Resolve** | The act of asking Restormel which provider + model + key to use for a request | "Route" (verb — too ambiguous), "select," "pick" |
+| **ModelSelector** | The embeddable UI component that lets end-users choose a model | "Model picker," "model dropdown" |
+| **KeyManager** | The embeddable UI component that lets end-users manage their provider credentials | "Key panel," "BYOK settings" |
+| **Dashboard** | The web app at `/keys/dashboard` where you configure projects, routes, policies | "Admin," "portal," "console" |
+| **Cloud API** | The HTTP API exposed via the Zuplo gateway | "REST API," "hosted API" |
+| **Consumer key** | A Zuplo-issued key (format `zpka_…`) for calling the Cloud API through the gateway | "Zuplo key," "external key" |
+
+### When to use which credential (auth cheat-sheet)
+
+| Credential | Scope | Use for | Never use for |
+|------------|--------|---------|----------------|
+| **Gateway Key** (`RESTORMEL_GATEWAY_KEY`, format `rk_…`) | Project + environment | Resolve API, project-scoped calls from your backend | Policies evaluate, workspace-level APIs, dashboard UI |
+| **Management Key** (`RESTORMEL_MANAGEMENT_KEY`, format `rk_…`) | Workspace | Policies evaluate (`/api/policies/*`), workspace-scoped automation | Resolve (use Gateway Key); do not send from the browser |
+| **Session** (dashboard login) | User + workspace | Dashboard UI: routes, policies, keys, logs | Server-side or API calls; use Management Key or Gateway Key instead |
+
+Use the Gateway Key in app env vars for resolve. Use the Management Key only in backend or secure automation when calling the evaluate endpoint. Never expose either key in the browser or in client-side code.
+
+### Provider names
+
+Always capitalise: **OpenAI**, **Anthropic**, **Google** (not "google" or "GCP" when referring to the AI provider).
+
+### Package names
+
+Always use the full npm scope: `@restormel/keys`, `@restormel/keys-react`, `@restormel/keys-svelte`, `@restormel/keys-elements`, `@restormel/keys-cli`. Never abbreviate to "the keys package" without first establishing the full name on the page.
+
+---
+
+## 3. Page structure template
+
+Every walkthrough page follows this skeleton:
+
+```markdown
+# Phase N — [Title]
+
+> **Time:** ~X minutes
+> **Prerequisites:** [Phase N-1] complete, [specific tool/access]
+> **You'll need:** [list of accounts, tools, or access]
+
+[1–2 sentence summary of what this phase achieves and why it matters.]
+
+---
+
+## Step N.1 — [Action verb] [object]
+
+[Instructions — short paragraphs, no more than 3–4 lines each.]
+
+### You'll see
+
+[Describe the visible outcome: a response, a UI change, a terminal output.]
+
+### How to test
+
+[Concrete verification step: a curl command, a dashboard check, a CLI command.]
+
+### Build-agent prompt: [short name]
+
+**Context docs:**
+- [list of walkthrough and repo docs this prompt needs]
+
+**Prompt:**
+
+> [fenced copy-paste block]
+
+**Gate:** [what must be true before moving on]
+
+---
+
+## Step N.2 — …
+
+[Repeat pattern.]
+
+---
+
+## Checkpoint
+
+[Summary: what you now have working, what's next.]
+
+**Next:** [Phase N+1 — Title](link)
+```
+
+---
+
+## 4. Callout types
+
+Use exactly these callout labels and styles. Do not invent new ones.
+
+| Label | When to use | In Svelte/docs |
+|-------|-------------|----------------|
+| **Tip** | Helpful shortcut or best practice that isn't strictly required | Use a styled block or component for tips (e.g. `.callout.tip`). |
+| **Pitfall** | Common mistake that wastes time or causes a confusing error | Use a caution-style callout. |
+| **If you see…** | Troubleshooting for a specific error message or unexpected state | Use a note-style callout with the error text. |
+| **Security** | Anything related to key handling, secret storage, or credential safety | Use a danger-style callout. |
+| **Dashboard** | When a step requires action in the Restormel dashboard UI | Use a note-style callout. |
+
+### Callout formatting rules
+
+- One callout per step maximum. If you need two, the step is too big — split it.
+- Callout text should be 1–3 sentences. If longer, it should be a subsection, not a callout.
+- Keep code blocks outside callouts: put the code block immediately after the callout so it renders correctly in the Svelte docs.
+
+---
+
+## 5. Code block conventions
+
+- **Language tags:** Always specify the language. Use `ts` for TypeScript, `bash` for shell commands, `json` for JSON responses. Never use bare ` ``` `.
+- **Imports:** Always show imports. Never assume the reader knows where a function comes from.
+- **Copy-paste ready:** Every code block should work if pasted into the right file. No `// ...` placeholders unless the omitted code is genuinely irrelevant and clearly labelled.
+- **File paths:** When a code block is meant for a specific file, include a comment on line 1: `// src/lib/server/restormel.ts` or `// app/api/resolve/route.ts`.
+- **Environment variables:** Show placeholder patterns, never real values. Use `RESTORMEL_GATEWAY_KEY=rk_your_key_here` not `RESTORMEL_GATEWAY_KEY=rk_abc123def456`.
+- **Framework-aware:** When a code example differs by framework, show the primary framework (Next.js App Router) first, then provide a tabbed or clearly-labelled alternative for SvelteKit and vanilla/Web Components.
+
+---
+
+## 6. Build-agent prompt conventions
+
+Build-agent prompts are fenced blocks that readers can paste directly into Cursor, Claude Code, or a similar coding agent. They follow strict rules:
+
+### Structure
+
+```markdown
+### Build-agent prompt: [short-kebab-name]
+
+**Context docs:**
+- `docs/walkthrough/[this-file].md` — [one-line reason]
+- `docs/02-architecture.md` — [one-line reason]
+- `packages/core/src/server/resolve.ts` — [one-line reason]
+- [any other files the agent needs to read first]
+
+**Prompt:**
+
+> You are working in [repo name / project context].
+>
+> **Goal:** [one sentence]
+>
+> **Steps:**
+> 1. [concrete action with file path]
+> 2. [concrete action with file path]
+> …
+>
+> **DO NOT:** [explicit guardrails]
+
+**Gate:** [what must be true for this prompt's work to be considered done]
+```
+
+### Rules
+
+- **Context docs are mandatory.** Every prompt lists the walkthrough page it belongs to, plus every repo doc or source file the agent should read before starting.
+- **One goal per prompt.** If a phase has multiple implementation tasks, use multiple prompts.
+- **File paths are explicit.** Never say "the resolve file" — say `packages/core/src/server/resolve.ts`.
+- **DO NOT blocks are mandatory.** Every prompt must include at least one guardrail.
+- **Gates are mandatory.** Every prompt ends with a concrete, verifiable acceptance criterion.
+- **No secrets in prompts.** Use placeholder patterns (`rk_your_key_here`). Include a `DO NOT: Commit real API keys or secrets` guardrail in every prompt that touches credentials.
+
+---
+
+## 7. Cross-reference conventions
+
+- **Internal walkthrough links:** Use relative paths: `[Phase 2](./04-phase-2-resolve)` (or the correct filename for the docs implementation).
+- **Existing docs links:** Use paths from the docs root: `[Framework compatibility](/keys/docs/compatibility/)`.
+- **Dashboard links:** Always use canonical URLs from `ux-contracts.md`: Dashboard → `/keys/dashboard`, Sign in → `/keys/dashboard/login`.
+- **External links:** Use `target="_blank"` and `rel="noopener noreferrer"` where the Svelte app renders links. Label clearly: `[OpenAI API docs](https://platform.openai.com/docs) (external)`.
+- **Repo file references (in prompts only):** Use repo-relative paths: `packages/core/src/server/resolve.ts`, `apps/dashboard/src/routes/keys/dashboard/api/projects/[id]/resolve/+server.ts`.
+
+---
+
+## 8. Length and density guidelines
+
+| Content type | Target length | Notes |
+|-------------|---------------|-------|
+| Page intro | 1–2 sentences | What this phase does and why |
+| Step instructions | 3–8 lines of prose | Break longer steps into sub-steps |
+| "You'll see" block | 2–5 lines | Include a small code/JSON snippet if helpful |
+| "How to test" block | 1–3 lines + one command | Should be runnable, not descriptive |
+| Build-agent prompt | 10–30 lines in the fenced block | Enough for a coding agent to act; not a full spec |
+| Callouts | 1–3 sentences | If longer, make it a subsection |
+| Checkpoint (page footer) | 2–4 sentences | Summarise state and link to next |
+
+---
+
+## 9. Accessibility and inclusivity
+
+- **No jargon without definition.** The first use of any term from the terminology table (§2) should be followed by a brief parenthetical if it's not self-evident from context.
+- **No assumptions about experience level.** The walkthrough is written for a developer who has built an AI-powered app but has never used Restormel Keys. They know what an API key is; they don't know what a "route step" is in this product.
+- **Screen reader friendly headings.** H2 headings should be descriptive enough to navigate by heading alone (e.g. "Step 2.1 — Call the resolve endpoint" not "Step 2.1").
+- **Alt text for diagrams.** Any mermaid or image must have a text summary.
+
+---
+
+## 10. Naming and file conventions for the walkthrough folder
+
+All walkthrough files live in a single folder (e.g. `docs/walkthrough/`). File naming:
+
+```
+docs/walkthrough/
+  00-index.md                    ← master index (committed last)
+  00-walkthrough-ia.md           ← docs IA and navigation
+  01-writing-style-guide.md      ← this file
+  02-phase-0-inventory.md        ← Phase 0 page spec
+  03-phase-1-install.md          ← Phase 1 page spec
+  04-phase-2-resolve.md          ← Phase 2 page spec
+  05-phase-3-routes.md           ← Phase 3 page spec
+  06-phase-4-policies.md         ← Phase 4 page spec
+  07-phase-5-ui.md               ← Phase 5 page spec
+  08-phase-6-golive.md           ← Phase 6 page spec
+  09-migration-paths.md          ← Migration guide
+  10-verification-strategy.md    ← Verification strategy
+  11-prompt-index.md             ← All prompts collected with context refs
+```
+
+---
+
+*Next file: `02-phase-0-inventory.md` — the "Before you begin" entry page and Phase 0 (inventory and remove custom routing).*

--- a/docs/walkthrough/02-phase-0-inventory.md
+++ b/docs/walkthrough/02-phase-0-inventory.md
@@ -1,0 +1,277 @@
+# Phase 0 — Inventory Your Routing
+
+> **Time:** ~30 minutes (audit) + implementation time varies
+> **Prerequisites:** Access to your app's codebase, a Restormel Keys account ([Sign in](https://restormel.dev/keys/dashboard/login))
+> **You'll need:** Your app's source code, terminal access, familiarity with where your app calls AI providers today
+
+---
+
+## Before you begin
+
+This walkthrough takes you from your current AI routing setup to a full Restormel Keys integration. By the end, your app uses Restormel for provider resolution, fallback routing, policy enforcement, and (optionally) embeddable UI for model selection and key management.
+
+### What you'll build across all phases
+
+| Phase | What you do | What you get |
+|-------|------------|--------------|
+| **0 — Inventory** | Audit and retire your custom routing | Clean separation; one place left to wire |
+| **1 — Install** | Add packages, create a project in the dashboard | Working config, `keys doctor` passes |
+| **2 — Resolve** | Make your first resolve call | Backend knows which provider + model to use |
+| **3 — Routes** | Configure routes with fallback steps | Automatic failover when a provider is down |
+| **4 — Policies** | Add allowlists, deprecation blocks, budget caps | Guardrails enforced before resolution |
+| **5 — UI** | Embed ModelSelector and/or KeyManager | End-users choose models within your policy constraints |
+| **6 — Go live** | Parallel run, cutover, verify | Production traffic through Restormel |
+
+### Key terms
+
+If these are unfamiliar, see the [Overview](/keys/docs/) page or the terms below. The most important for Phase 0:
+
+- **Resolve** — asking Restormel which provider + model + key source to use for a request.
+- **Route** — a named routing configuration in the dashboard; contains steps (a fallback chain).
+- **Policy** — a rule that constrains resolution (e.g. "only allow these models").
+- **Gateway Key** — the `rk_…` key your backend uses to authenticate to Restormel.
+
+### Skip ahead
+
+Already done some of this? Jump to the phase you need:
+
+- Packages installed and project created → [Phase 2 — Resolve](/keys/docs/walkthrough/phase-2-resolve)
+- Routes configured → [Phase 4 — Policies](/keys/docs/walkthrough/phase-4-policies)
+- Coming from LiteLLM, Portkey, or OpenRouter → [Migration paths](/keys/docs/walkthrough/migration-paths)
+
+---
+
+## Why Phase 0 matters
+
+Most apps that need Restormel Keys already have _something_ doing provider routing — even if it's a hardcoded `if/else` or a config file mapping models to providers. Phase 0 is about finding all of those pieces so you can retire them cleanly rather than running two routing systems in parallel indefinitely.
+
+You are not deleting anything yet. You are making an inventory so the replacement in later phases is surgical.
+
+---
+
+## Step 0.1 — Identify your current routing surface
+
+Search your codebase for the code that currently decides which AI provider and model to use for a given request.
+
+**Look for:**
+
+- Direct provider SDK imports (`openai`, `@anthropic-ai/sdk`, `@google/generative-ai`) — where are they called, and what decides _which_ one to call?
+- Environment variables like `DEFAULT_MODEL`, `AI_PROVIDER`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` — who reads them and how do they affect routing?
+- Custom router/gateway modules — any file named `router`, `provider`, `gateway`, `ai-client`, `model-selector`, or similar.
+- Fallback logic — `try/catch` blocks that retry with a different provider on failure.
+- Model selection UI — any dropdown, radio group, or settings page where users pick a model.
+- BYOK settings — any UI or API where users paste their own provider API keys.
+
+### You'll see
+
+A list of files and modules. Organise them into three categories:
+
+| Category | What it contains | Example |
+|----------|-----------------|---------|
+| **Routing logic** | Code that chooses provider/model | `src/lib/server/ai-router.ts`, `src/lib/ai/fallback.ts` |
+| **Model selection UI** | Frontend components for model/provider choice | `src/components/ModelPicker.svelte`, `app/settings/page.tsx` |
+| **BYOK / key management** | Storage, validation, or UI for user-provided API keys | `src/lib/server/byok.ts`, `src/components/KeySettings.tsx` |
+
+### How to test
+
+There's nothing to test yet — this is an audit. Confirm you can answer: "If I grep for every place my app decides which AI provider to call, these are the files."
+
+> **Tip**
+> Use your IDE’s “Find all references” on provider client constructors (e.g. `new OpenAI(...)`, `new Anthropic(...)`) to trace where provider choice happens. It’s often faster than searching for strings.
+
+---
+
+## Step 0.2 — Classify each piece: remove, keep, or wrap
+
+For each item in your inventory, decide its fate:
+
+| Decision | When to use it | Action |
+|----------|---------------|--------|
+| **Remove** | Custom routing logic that Restormel will replace entirely (fallback chains, provider health checks, model allowlists) | Mark for deletion in Phase 2+. Do not delete yet. |
+| **Keep** | App-specific logic that Restormel does not own (billing, auth, session, orchestration/job logic, domain-specific pre/post-processing) | Leave untouched. |
+| **Wrap** | Code that currently calls providers directly but should call Restormel resolve first, then call the provider with the resolved result | Refactor in Phase 2 to insert a resolve call before the provider call. |
+
+### You'll see
+
+An annotated version of your inventory. For example:
+
+```text
+REMOVE  src/lib/server/ai-router.ts        — custom fallback chain, replaced by Restormel routes
+REMOVE  src/lib/server/model-allowlist.ts   — hardcoded model list, replaced by Restormel policies
+KEEP    src/lib/server/billing/wallet.ts    — billing logic, not routing
+KEEP    src/lib/server/ingestion/worker.ts  — job orchestration (but calls ai-router internally)
+WRAP    src/lib/server/ingestion/worker.ts  — replace ai-router call with Restormel resolve
+REMOVE  src/components/ModelPicker.svelte   — custom model UI, replaced by Restormel ModelSelector
+WRAP    src/components/KeySettings.tsx       — BYOK UI, may replace with Restormel KeyManager or keep as wrapper
+```
+
+### How to test
+
+Review your annotations with a second pair of eyes (or a coding agent). Confirm: every "REMOVE" item has a Restormel equivalent identified in the phases ahead. Every "KEEP" item genuinely has no routing responsibility.
+
+> **Pitfall**
+> Do not remove anything in this step. Phase 0 is audit-only. Deletion happens in Phase 2+ after the replacement is wired and tested.
+
+---
+
+## Step 0.3 — Document the current provider call pattern
+
+Before you change anything, record how your app currently calls AI providers. This becomes your regression baseline.
+
+Write down (or have a coding agent extract):
+
+1. **Entry points:** Which functions/routes initiate an AI provider call? (e.g. `POST /api/chat`, ingestion worker, background job)
+2. **Selection logic:** For each entry point, how is provider + model chosen today? (e.g. env var, user preference, hardcoded, fallback chain)
+3. **Credential source:** Where does the API key come from? (e.g. env var, user BYOK from database, config file)
+4. **Error handling:** What happens when a provider call fails? (e.g. retry same provider, fallback to different provider, return error to user)
+5. **Observability:** Are provider calls logged? Do you track which provider/model was used, latency, cost?
+
+### You'll see
+
+A short document or code comment block that captures the current state. This is your "before" snapshot.
+
+### How to test
+
+Pick one entry point. Trace the request from "user action" to "provider API call" and back. Confirm your documentation matches reality.
+
+### Build-agent prompt: inventory-current-routing
+
+**Context docs** (use in the Restormel Keys repo or adapt paths for your project):
+
+- `docs/walkthrough/02-phase-0-inventory.md` — this page (the audit framework)
+- `docs/02-architecture.md` — §1 "Framework compatibility" and §2 "Package structure" (understand what Restormel replaces)
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Audit the codebase to produce a routing inventory for Restormel Keys integration.
+>
+> **Steps:**
+>
+> 1. Search for all AI provider SDK imports (`openai`, `@anthropic-ai/sdk`, `@google/generative-ai`, or equivalent). List every file that creates a provider client or calls a completion/chat endpoint.
+> 2. For each file found, trace backwards: what decides which provider and model to use? List the routing/selection logic files.
+> 3. Search for model selection UI (dropdowns, selectors, settings pages that let users choose a model or provider). List those components.
+> 4. Search for BYOK / key management code (where users paste or store their own provider API keys). List those files.
+> 5. For each item, classify as REMOVE (Restormel replaces it), KEEP (app-specific, not routing), or WRAP (insert Restormel resolve before the existing provider call).
+> 6. Document the current provider call pattern for at least one primary entry point: entry point → selection logic → credential source → provider call → error handling.
+> 7. Write the results to `docs/restormel-integration/00-routing-inventory.md` (or your equivalent docs folder).
+>
+> **DO NOT:**
+> - Delete or modify any existing code. This is audit-only.
+> - Commit real API keys or secrets in the inventory document.
+> - Guess about routing logic — trace the actual code paths.
+
+**Gate:** A routing inventory document exists that lists every routing/selection/BYOK file, classifies each as REMOVE/KEEP/WRAP, and documents at least one end-to-end provider call pattern.
+
+---
+
+## Step 0.4 — Plan the replacement sequence
+
+Based on your inventory, plan which walkthrough phases address which items:
+
+| Inventory item | Replaced by | Walkthrough phase |
+|----------------|------------|-------------------|
+| Custom fallback chain | Restormel routes + steps | Phase 3 |
+| Hardcoded model allowlist | Restormel policies (model_allowlist) | Phase 4 |
+| Provider selection logic | Restormel resolve call | Phase 2 |
+| Model picker UI | Restormel ModelSelector component | Phase 5 |
+| BYOK settings UI | Restormel KeyManager component (or keep as wrapper) | Phase 5 |
+| Provider API key env vars | Restormel Gateway Key + provider credentials in dashboard | Phase 1 |
+
+### You'll see
+
+A mapping table specific to your app. Not every row will apply — some apps have no BYOK, some have no fallback logic.
+
+### How to test
+
+Walk through each row and confirm: "When Phase N is complete, this inventory item will be retired." If any item has no corresponding phase, it either belongs in "KEEP" or you need to identify which phase handles it.
+
+---
+
+## Step 0.5 — Set up a feature flag (optional but recommended)
+
+If your app supports feature flags, create one now: `USE_RESTORMEL_KEYS` (or equivalent). This lets you run old and new routing in parallel during Phases 2–6 and roll back instantly if something breaks.
+
+```ts
+// src/lib/feature-flags.ts
+export const USE_RESTORMEL_KEYS = process.env.USE_RESTORMEL_KEYS === 'true';
+```
+
+In your routing code, the eventual pattern will be:
+
+```ts
+// src/lib/server/resolve-provider.ts
+import { USE_RESTORMEL_KEYS } from '../feature-flags';
+
+export async function resolveProvider(request: AIRequest) {
+  if (USE_RESTORMEL_KEYS) {
+    // New path: call Restormel resolve
+    return await restormelResolve(request);
+  }
+  // Old path: existing custom routing
+  return await legacyRouter.resolve(request);
+}
+```
+
+You'll wire `restormelResolve` in Phase 2. For now, the flag just exists.
+
+### You'll see
+
+A feature flag that defaults to `false`. Your app behaves identically to before.
+
+### How to test
+
+```bash
+# Confirm the flag defaults to off
+echo $USE_RESTORMEL_KEYS  # should be empty or unset
+
+# Confirm your app starts normally with the flag file added
+pnpm dev  # or your start command
+```
+
+### Build-agent prompt: add-feature-flag
+
+**Context docs** (adapt paths for your project):
+
+- This page — §0.5 feature flag pattern
+- Phase 2 — where the flag gets used for the resolve call
+- Phase 6 — where the flag gets flipped to `true` for production
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Add a feature flag `USE_RESTORMEL_KEYS` to gate the Restormel Keys integration.
+>
+> **Steps:**
+>
+> 1. Create a feature flags module (e.g. `src/lib/feature-flags.ts` or the equivalent for your framework) that exports `USE_RESTORMEL_KEYS`, reading from `process.env.USE_RESTORMEL_KEYS` and defaulting to `false`.
+> 2. Identify the primary function(s) that currently resolve which AI provider to call (from the routing inventory in `docs/restormel-integration/00-routing-inventory.md`).
+> 3. In each of those functions, add a conditional branch: if `USE_RESTORMEL_KEYS` is true, call a placeholder `restormelResolve()` function (which throws "not yet implemented" for now); otherwise, call the existing logic unchanged.
+> 4. Add `USE_RESTORMEL_KEYS=false` to `.env.example` (not `.env`).
+> 5. Verify the app starts and behaves identically with the flag unset.
+>
+> **DO NOT:**
+> - Set the flag to `true` yet. That happens in Phase 6.
+> - Modify any existing routing logic. Only add the conditional branch around it.
+> - Implement `restormelResolve` yet. It's a placeholder that throws.
+> - Commit real API keys or secrets.
+
+**Gate:** App starts with no behaviour change. A `USE_RESTORMEL_KEYS` env var exists in `.env.example`. The conditional branch is in place but the old path runs by default.
+
+---
+
+## Checkpoint
+
+You now have:
+
+- A routing inventory listing every file that participates in AI provider selection, model choice, and BYOK.
+- Each item classified as REMOVE, KEEP, or WRAP.
+- A documented "before" snapshot of at least one provider call pattern.
+- A replacement mapping showing which walkthrough phase handles each inventory item.
+- (Optional) A feature flag ready to gate the new routing path.
+
+Nothing has been deleted or changed. Your app runs exactly as before.
+
+**Next:** [Phase 1 — Install and configure](/keys/docs/walkthrough/phase-1-install) — add the Restormel Keys packages, create a project in the dashboard, and run `keys doctor`.

--- a/docs/walkthrough/03-phase-1-install.md
+++ b/docs/walkthrough/03-phase-1-install.md
@@ -1,0 +1,286 @@
+# Phase 1 — Install and Configure
+
+> **Time:** ~15 minutes
+> **Prerequisites:** [Phase 0](./02-phase-0-inventory.md) complete (routing inventory exists), a Restormel Keys account
+> **You'll need:** Terminal access, your app's package manager (`pnpm`, `npm`, or `yarn`), access to the [Dashboard](https://restormel.dev/keys/dashboard)
+
+This phase gets the Restormel Keys packages into your project and creates the dashboard-side resources (workspace, project, environment, Gateway Key) that later phases depend on. By the end, `keys doctor` passes (framework, packages, and local config) and your dashboard shows a project ready for routes and policies. The CLI does not validate Cloud env vars (e.g. `RESTORMEL_GATEWAY_KEY`, `RESTORMEL_PROJECT_ID`) today — you verify those in Phase 2 when you make your first resolve call.
+
+---
+
+## Step 1.1 — Install the packages
+
+Choose the packages for your framework. The headless core (`@restormel/keys`) is always required. Add UI packages if you plan to embed ModelSelector or KeyManager (Phase 5).
+
+**Next.js / React:**
+
+```bash
+pnpm add @restormel/keys @restormel/keys-react @restormel/keys-elements
+```
+
+**SvelteKit:**
+
+```bash
+pnpm add @restormel/keys @restormel/keys-svelte
+```
+
+**Vanilla / Astro / Web Components:**
+
+```bash
+pnpm add @restormel/keys @restormel/keys-elements
+```
+
+**Server-only (no UI, just resolve):**
+
+```bash
+pnpm add @restormel/keys
+```
+
+> **Tip**
+> Not sure which packages you need? See [Framework compatibility](/keys/docs/compatibility/) for the full decision tree. If you only need server-side resolution and no embedded UI, the headless core is enough.
+
+### You'll see
+
+The packages appear in your `package.json` dependencies. No build errors.
+
+### How to test
+
+```bash
+# Confirm the package installed correctly
+node -e "const k = require('@restormel/keys'); console.log('OK:', Object.keys(k).length, 'exports')"
+```
+
+If you use ESM (`"type": "module"` in your `package.json`):
+
+```bash
+node --input-type=module -e "import { createKeys } from '@restormel/keys'; console.log('OK: createKeys is', typeof createKeys)"
+```
+
+---
+
+## Step 1.2 — Scaffold with the CLI
+
+The CLI generates a starter config and validates your setup. If you prefer to configure manually, skip to Step 1.3.
+
+```bash
+npx @restormel/keys-cli init
+```
+
+The `init` command detects your framework, suggests the right packages (confirming what you installed in 1.1), and creates a `restormel.config.json` in your project root.
+
+### You'll see
+
+Interactive prompts asking for your framework, which providers you use, and your preferred storage adapter. On completion:
+
+```
+✔ Detected framework: Next.js (App Router)
+✔ Created restormel.config.json
+✔ Suggested packages: @restormel/keys, @restormel/keys-react, @restormel/keys-elements
+
+Run 'keys doctor' to verify your setup.
+```
+
+### How to test
+
+```bash
+npx @restormel/keys-cli doctor
+```
+
+`doctor` checks framework detection, package versions, config validity, and key health. At this point it should pass with a note that no Gateway Key is configured yet (that's Step 1.4).
+
+:::note[If you see "framework not detected"]
+The CLI looks for framework markers (`next.config.*`, `svelte.config.*`, `astro.config.*`). If your project uses a non-standard layout, run `keys init --framework next` (or `sveltekit`, `react`, `astro`) to specify manually.
+:::
+
+---
+
+## Step 1.3 — Create a project in the Dashboard
+
+Open the [Dashboard](https://restormel.dev/keys/dashboard) and sign in with GitHub.
+
+1. **Create a workspace** (if you don't have one). This is your top-level organisational container. Name it after your company or team.
+2. **Create a project.** Name it after your app (e.g. "My Writing Tool" or "SOPHIA Ingestion"). The project is where routes, policies, and keys live.
+3. **Create an environment** within the project: `production`. You can add `staging` later. The environment scopes routes and policies to a deployment context.
+
+> **Dashboard**
+> Workspace → Projects → **Create project** → name it → **Environments** → **Create environment** → name it `production`.
+
+### You'll see
+
+The project detail page in the dashboard with:
+- Project name and ID
+- An "Environments" section showing `production`
+- Empty "Routes" and "Policies" sections (you'll fill these in Phases 3–4)
+- An "API Keys" section (you'll generate a Gateway Key next)
+
+### How to test
+
+The project detail page loads without errors. The environment `production` is listed.
+
+---
+
+## Step 1.4 — Generate a Gateway Key
+
+Still in the Dashboard, on your project detail page:
+
+1. Click **Generate API key** (or navigate to the API Keys section).
+2. Copy the full key immediately. It has the format `rk_…` and is shown only once.
+3. Store it securely. This is your **Gateway Key** — the credential your backend uses to authenticate to the Restormel resolve API.
+
+> **Security**
+> The Gateway Key is a secret. Store it in your environment variables or secret manager. Never commit it to your repo, paste it into a coding agent, or log it in application output.
+
+### You'll see
+
+A key displayed once with a "Copy" button. After you navigate away, you'll see only the key prefix (e.g. `rk_a3f…`) in the dashboard — the full key is not retrievable.
+
+### How to test
+
+You'll test the key works in Phase 2 when you make your first resolve call. For now, confirm it's stored:
+
+```bash
+# Add to your .env (gitignored) — NOT .env.example
+echo "RESTORMEL_GATEWAY_KEY=rk_your_key_here" >> .env
+echo "RESTORMEL_PROJECT_ID=your_project_id_here" >> .env
+echo "RESTORMEL_ENVIRONMENT_ID=production" >> .env
+```
+
+Update `.env.example` with placeholder names (no values):
+
+```bash
+# .env.example
+RESTORMEL_GATEWAY_KEY=
+RESTORMEL_PROJECT_ID=
+RESTORMEL_ENVIRONMENT_ID=
+```
+
+---
+
+## Step 1.5 — Configure provider credentials (optional now)
+
+If your app uses **platform keys** (your own OpenAI/Anthropic/Google keys, not user-provided BYOK), you can add them as provider credentials in the dashboard now. This is optional — you can also continue using your existing env vars and let Restormel resolve point to the provider while you supply the key yourself.
+
+To add provider credentials in the dashboard:
+
+1. In your project, go to **Provider Credentials**.
+2. Click **Add credential**, choose the provider (e.g. OpenAI), paste your API key.
+3. Restormel validates the key and stores it encrypted.
+
+If you prefer to keep provider keys in your own env vars and only use Restormel for routing decisions, skip this step. The resolve response tells you _which_ provider to call; you can supply the key from your own env.
+
+### You'll see
+
+The credential listed in the dashboard with the provider name and a masked key preview. Validation status shows green if the key is valid.
+
+### How to test
+
+No code-level test yet. The dashboard shows the credential as valid.
+
+---
+
+## Step 1.6 — Run `keys doctor` again
+
+Now that you have a config (and optionally env vars), run the doctor check again:
+
+```bash
+npx @restormel/keys-cli doctor
+```
+
+### You'll see
+
+`keys doctor` checks framework detection, package versions, and config validity. Example output:
+
+```
+✔ Framework: Next.js (App Router)
+✔ Packages: @restormel/keys@0.2.0, @restormel/keys-react@0.1.0, @restormel/keys-elements@0.1.0
+✔ Config: restormel.config.json valid
+
+All checks passed.
+```
+
+Cloud env vars (`RESTORMEL_GATEWAY_KEY`, `RESTORMEL_PROJECT_ID`, `RESTORMEL_ENVIRONMENT_ID`) are not validated by the CLI. You confirm they work in Phase 2 when you call the resolve endpoint.
+
+### How to test
+
+`keys doctor` exits with code 0.
+
+```bash
+npx @restormel/keys-cli doctor && echo "PASS" || echo "FAIL"
+```
+
+> **Pitfall**
+> If `doctor` reports missing packages, install them (Step 1.1). If it reports a missing config, run `keys init` (Step 1.2). For resolve to work in Phase 2, ensure your `.env` (or secret manager) has the Gateway Key and project/environment IDs and that your app loads them at runtime.
+
+---
+
+## Step 1.7 — Add env var placeholders to `.env.example`
+
+Make sure your repo's `.env.example` documents the new variables so collaborators know what to set:
+
+```bash
+# .env.example — Restormel Keys integration
+RESTORMEL_GATEWAY_KEY=
+RESTORMEL_PROJECT_ID=
+RESTORMEL_ENVIRONMENT_ID=
+# Optional: feature flag for phased rollout (see Phase 0)
+USE_RESTORMEL_KEYS=false
+```
+
+### Build-agent prompt: install-and-configure
+
+**Context docs:**
+- `docs/walkthrough/03-phase-1-install.md` — this page
+- `docs/02-architecture.md` — §1 framework compatibility, §2 package structure (which packages for which framework)
+- `docs/walkthrough/02-phase-0-inventory.md` — routing inventory (confirms what framework the app uses)
+- `packages/core/src/keys.ts` — `createKeys` function signature
+- `packages/cli/README.md` — CLI commands (`keys init`, `keys doctor`)
+- `docs/ux-contracts.md` — canonical URLs for Dashboard links
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Install Restormel Keys packages, scaffold the config, and prepare env vars for integration.
+>
+> **Steps:**
+>
+> 1. Read the routing inventory at `docs/restormel-integration/00-routing-inventory.md` to confirm the framework and whether UI packages are needed.
+> 2. Install the correct packages for this framework:
+>    - Next.js/React: `pnpm add @restormel/keys @restormel/keys-react @restormel/keys-elements`
+>    - SvelteKit: `pnpm add @restormel/keys @restormel/keys-svelte`
+>    - Server-only: `pnpm add @restormel/keys`
+> 3. Run `npx @restormel/keys-cli init` and accept the detected framework and suggested packages.
+> 4. Add to `.env.example` (placeholder names only, no values):
+>    ```
+>    RESTORMEL_GATEWAY_KEY=
+>    RESTORMEL_PROJECT_ID=
+>    RESTORMEL_ENVIRONMENT_ID=
+>    USE_RESTORMEL_KEYS=false
+>    ```
+> 5. If a `.env` file exists and is gitignored, add the same keys with empty values there as well.
+> 6. Run `npx @restormel/keys-cli doctor` and confirm it exits 0 (ignoring the "no gateway key" warning if `.env` values are empty).
+> 7. Commit `restormel.config.json`, `.env.example` changes, and `package.json` / lockfile changes.
+>
+> **DO NOT:**
+> - Commit real API keys or secrets to the repo.
+> - Add values to `.env.example` — only placeholder names.
+> - Modify any existing application code. This prompt is install-and-configure only.
+> - Install packages that don't match the framework (e.g. don't install `@restormel/keys-react` in a SvelteKit-only project).
+
+**Gate:** `npx @restormel/keys-cli doctor` exits 0. `restormel.config.json` exists and is committed. `.env.example` lists the four Restormel env vars. No real keys are committed.
+
+---
+
+## Checkpoint
+
+You now have:
+
+- Restormel Keys packages installed in your project.
+- A `restormel.config.json` that matches your framework.
+- A project and environment created in the Restormel Dashboard.
+- A Gateway Key stored in your `.env` (gitignored).
+- `keys doctor` passing.
+
+Your app still runs on the old routing path (the feature flag from Phase 0 is still `false`). Nothing has changed in your application behaviour.
+
+**Next:** [Phase 2 — Resolve your first model](./04-phase-2-resolve.md) — make your first resolve call from your backend and see the response.

--- a/docs/walkthrough/04-phase-2-resolve.md
+++ b/docs/walkthrough/04-phase-2-resolve.md
@@ -1,0 +1,415 @@
+# Phase 2 — Resolve Your First Model
+
+> **Time:** ~15 minutes
+> **Prerequisites:** [Phase 1](/keys/docs/walkthrough/phase-1-install) complete (packages installed, project created, Gateway Key in `.env`, `keys doctor` passes)
+> **You'll need:** Terminal access, a running dev server (or `curl`/`httpie`), your Gateway Key and Project ID from the dashboard
+
+This phase wires a single resolve call into your backend. By the end, your app can ask Restormel "which provider and model should I use for this request?" and get a concrete answer. You'll verify the response shape, then plug it into the feature-flag branch from Phase 0.
+
+---
+
+## Step 2.1 — Understand the resolve flow
+
+Before writing code, understand what happens when your backend calls resolve:
+
+1. Your backend sends a `POST` to the resolve endpoint with your project ID and environment.
+2. Restormel evaluates the project's routes (fallback chain) and policies (allowlists, budgets, etc.).
+3. Restormel returns a JSON object telling you which provider, model, and key source to use.
+4. Your backend calls the AI provider directly using that information.
+
+Restormel does **not** proxy the AI request. It tells you _where_ to send it; you send it yourself. This keeps latency low and means your provider API keys never transit through Restormel (unless you've stored provider credentials in the dashboard and want Restormel to supply them).
+
+---
+
+## Step 2.2 — Test resolve with curl
+
+Before writing any application code, confirm the resolve endpoint works with a raw HTTP call. This isolates Restormel from your app so you can verify the plumbing.
+
+```bash
+curl -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production" }'
+```
+
+> **Tip**
+> If you use the Cloud API through the Zuplo gateway, the URL is your gateway URL instead of the dashboard URL, and you authenticate with your consumer key (`zpka_…`). For this walkthrough, we use the dashboard API directly with the Gateway Key. See [Cloud API](/keys/docs/cloud-api/) for the gateway path.
+
+### You'll see
+
+A JSON response wrapped under `data`:
+
+```json
+{
+  "data": {
+    "routeId": "route_123",
+    "providerType": "openai",
+    "modelId": "gpt-4o",
+    "explanation": "route=route_123 step=0 provider=openai model=gpt-4o"
+  }
+}
+```
+
+**Reading the response:**
+
+| Field | Meaning |
+|-------|---------|
+| `data.routeId` | The matched route ID (created in the dashboard in Phase 3) |
+| `data.providerType` | The AI provider to call (e.g. `openai`, `anthropic`, `google`) |
+| `data.modelId` | The model to use (from the first enabled step, or the route default); may be `null` if none configured |
+| `data.explanation` | A human-readable trace of the resolution path (useful for debugging) |
+
+If you have not created a route for this `environmentId` yet, resolve returns **404** with `{ error: "no_route" }`. That is expected — you create your first route in Phase 3.
+
+### How to test
+
+The curl command returns HTTP 200 and a JSON body with `data.providerType`. If you get:
+
+- **401 Unauthorized** — your Gateway Key is wrong or missing. Check `$RESTORMEL_GATEWAY_KEY`.
+- **404 Not Found** — your project ID is wrong. Check `$RESTORMEL_PROJECT_ID` against the dashboard.
+- **404 no_route** — your project has no active route for the `environmentId` you sent. Create a route for that environment in Phase 3.
+
+> **If you see "no_key_available"**
+> Your route's steps point at providers that are not currently usable (for example: you have not configured steps yet, all steps are disabled, or the steps reference providers/models that can't be used). Create a route with at least one enabled step (Phase 3). If you only want Restormel to choose a route while you supply provider credentials in your own app, use local resolve (Step 2.6) instead of the dashboard resolve endpoint.
+
+---
+
+## Step 2.3 — Create a typed resolve client
+
+Add a small server-side module that calls the resolve endpoint. This becomes the single place your app asks Restormel for routing decisions.
+
+**Next.js / generic Node (TypeScript):**
+
+```ts
+// src/lib/server/restormel.ts
+
+interface ResolveRequest {
+  environmentId: string;
+  routeId?: string;
+}
+
+interface ResolveResponse {
+  data: {
+    routeId: string;
+    providerType: string | null;
+    modelId: string | null;
+    explanation: string;
+  };
+}
+
+const RESTORMEL_BASE_URL = process.env.RESTORMEL_BASE_URL
+  ?? 'https://restormel.dev/keys/dashboard';
+const RESTORMEL_GATEWAY_KEY = process.env.RESTORMEL_GATEWAY_KEY ?? '';
+const RESTORMEL_PROJECT_ID = process.env.RESTORMEL_PROJECT_ID ?? '';
+
+export async function restormelResolve(
+  request: ResolveRequest
+): Promise<ResolveResponse> {
+  const url = `${RESTORMEL_BASE_URL}/api/projects/${RESTORMEL_PROJECT_ID}/resolve`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${RESTORMEL_GATEWAY_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Restormel resolve failed (${res.status}): ${body.slice(0, 200)}`
+    );
+  }
+
+  return res.json() as Promise<ResolveResponse>;
+}
+```
+
+**SvelteKit:**
+
+```ts
+// src/lib/server/restormel.ts
+// Same implementation as above — SvelteKit server modules use the same Node/fetch APIs.
+// Import with: import { restormelResolve } from '$lib/server/restormel';
+```
+
+### You'll see
+
+A new file at `src/lib/server/restormel.ts` (or equivalent). No UI changes. No behaviour changes yet.
+
+### How to test
+
+Import the function in a test or scratch script and call it:
+
+```ts
+// scripts/test-resolve.ts (run with tsx or ts-node)
+import { restormelResolve } from '../src/lib/server/restormel';
+
+const result = await restormelResolve({ environmentId: 'production' });
+console.log('Resolved:', JSON.stringify(result, null, 2));
+```
+
+```bash
+npx tsx scripts/test-resolve.ts
+```
+
+You should see the same JSON structure as the curl response from Step 2.2.
+
+---
+
+## Step 2.4 — Wire resolve into the feature flag
+
+Connect the resolve client to the feature-flag branch you created in Phase 0 (Step 0.5). This is the moment your app can optionally route through Restormel — but still defaults to the old path.
+
+```ts
+// src/lib/server/resolve-provider.ts
+import { USE_RESTORMEL_KEYS } from '../feature-flags';
+import { restormelResolve } from './restormel';
+
+interface ProviderDecision {
+  provider: string;
+  model: string | null;
+  source: 'restormel' | 'legacy';
+}
+
+export async function resolveProvider(
+  preferredModel?: string
+): Promise<ProviderDecision> {
+  if (USE_RESTORMEL_KEYS) {
+    const result = await restormelResolve({
+      environmentId: process.env.RESTORMEL_ENVIRONMENT_ID ?? 'production',
+    });
+    return {
+      provider: result.data.providerType ?? (process.env.DEFAULT_AI_PROVIDER ?? 'openai'),
+      model: result.data.modelId ?? preferredModel ?? null,
+      source: 'restormel',
+    };
+  }
+
+  // Legacy path — your existing routing logic
+  return legacyResolve(preferredModel);
+}
+
+function legacyResolve(preferredModel?: string): ProviderDecision {
+  // Your existing provider selection logic goes here.
+  // This is a placeholder — replace with your actual legacy code.
+  return {
+    provider: process.env.DEFAULT_AI_PROVIDER ?? 'openai',
+    model: preferredModel ?? process.env.DEFAULT_AI_MODEL ?? null,
+    source: 'legacy',
+  };
+}
+```
+
+### You'll see
+
+Your existing routing code still runs (the flag is `false`). The new path exists but is not active.
+
+### How to test
+
+**Test the legacy path (flag off — default):**
+
+```bash
+# Start your app normally
+pnpm dev
+# Make a request that triggers an AI call — it should behave identically to before
+```
+
+**Test the Restormel path (flag on — temporary):**
+
+```bash
+# Start with the flag enabled
+USE_RESTORMEL_KEYS=true pnpm dev
+# Make the same request — it should now resolve via Restormel
+# Check your terminal/logs for the resolved provider
+```
+
+Turn the flag back off after testing. Production cutover happens in Phase 6.
+
+> **Pitfall**
+> If the Restormel path returns `no_key_available` and your app crashes, add error handling: catch the resolve error and fall back to the legacy path. This is your safety net during the parallel-run period.
+
+---
+
+## Step 2.5 — Add error handling and local fallback
+
+The resolve call is a network request. It can fail (network error, Restormel downtime, misconfiguration). Your app should handle this gracefully.
+
+```ts
+// src/lib/server/resolve-provider.ts — updated resolveProvider
+
+export async function resolveProvider(
+  preferredModel?: string
+): Promise<ProviderDecision> {
+  if (USE_RESTORMEL_KEYS) {
+    try {
+      const result = await restormelResolve({
+        environmentId: process.env.RESTORMEL_ENVIRONMENT_ID ?? 'production',
+      });
+      return {
+        provider: result.data.providerType ?? (process.env.DEFAULT_AI_PROVIDER ?? 'openai'),
+        model: result.data.modelId ?? preferredModel ?? null,
+        source: 'restormel',
+      };
+    } catch (err) {
+      console.error('[restormel] Resolve failed, falling back to legacy:', err);
+      // Fall through to legacy path
+    }
+  }
+
+  return legacyResolve(preferredModel);
+}
+```
+
+### You'll see
+
+If Restormel is unreachable or returns an error, your app logs the error and continues with the legacy routing path. No user-facing impact.
+
+### How to test
+
+Temporarily set an invalid Gateway Key and enable the flag:
+
+```bash
+RESTORMEL_GATEWAY_KEY=rk_invalid USE_RESTORMEL_KEYS=true pnpm dev
+```
+
+Make a request that triggers an AI call. You should see a console error like `[restormel] Resolve failed, falling back to legacy: Error: Restormel resolve failed (401)` and the request should succeed via the legacy path.
+
+Restore your real Gateway Key after testing.
+
+### Build-agent prompt: create-resolve-client
+
+**Context docs** (adapt paths for your project): this page; Phase 0 (routing inventory, feature flag).
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Create a typed Restormel resolve client, wire it into the feature flag from Phase 0, and add error handling with legacy fallback.
+>
+> **Steps:**
+>
+> 1. Identify the legacy function that currently resolves which provider to call (from your routing inventory).
+> 2. Create `src/lib/server/restormel.ts` (or equivalent) with:
+>    - `ResolveRequest`: `{ environmentId: string; routeId?: string }`.
+>    - `ResolveResponse`: `{ data: { routeId: string; providerType: string | null; modelId: string | null; explanation: string } }`.
+>    - `restormelResolve(request)`: POST to `${RESTORMEL_BASE_URL}/api/projects/${RESTORMEL_PROJECT_ID}/resolve` with `Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}` and JSON body. Throw on non-2xx with status and truncated body.
+> 3. Create or update `src/lib/server/resolve-provider.ts`: if `USE_RESTORMEL_KEYS` is true, call `restormelResolve` in try/catch; on failure, log and fall through to legacy. Map `result.data.providerType` and `result.data.modelId` to your provider decision. If the flag is false or resolve failed, call legacy logic.
+> 4. Add `RESTORMEL_BASE_URL=https://restormel.dev/keys/dashboard` to `.env.example`.
+> 5. Create `scripts/test-resolve.ts`: call `restormelResolve({ environmentId: 'production' })` and log the result. Run with `npx tsx scripts/test-resolve.ts`.
+> 6. Verify: flag off → app unchanged; flag on → resolves via Restormel; flag on + invalid key → fallback to legacy and log error.
+>
+> **DO NOT:** Set `USE_RESTORMEL_KEYS=true` as default. Log the Gateway Key or raw keys. Modify legacy logic. Commit real API keys or secrets.
+
+**Gate:** Test script prints a valid resolve response with `data.providerType`. Flag off → unchanged behaviour. Flag on → Restormel path or legacy fallback. No secrets committed.
+
+---
+
+## Step 2.6 — (Optional) Use the npm package resolve middleware instead of HTTP
+
+If your backend is Node/TypeScript and you prefer to resolve locally (no HTTP call to the dashboard), you can use the `createResolveMiddleware` from `@restormel/keys/server` directly. This uses the same routing engine but runs in-process.
+
+This approach is useful if:
+- You want zero added latency from a network call.
+- You manage provider keys entirely in your own env vars (not in the dashboard).
+- You don't need dashboard-configured routes and policies yet (you'll add them later via the API or manually).
+
+```ts
+// src/lib/server/restormel-local.ts
+import { createKeys, openaiProvider, anthropicProvider, googleProvider } from '@restormel/keys';
+import { createResolveMiddleware } from '@restormel/keys/server';
+import type { ResolveContext } from '@restormel/keys/server';
+
+const keys = createKeys(
+  {
+    keys: [],
+    routing: {
+      defaultProvider: 'openai',
+      rules: ['openai', 'anthropic', 'google'], // fallback order
+    },
+  },
+  {
+    providers: [openaiProvider, anthropicProvider, googleProvider],
+    getPlatformKey: (provider) => {
+      // Look up provider keys from your own env vars
+      const map: Record<string, string | undefined> = {
+        openai: process.env.OPENAI_API_KEY,
+        anthropic: process.env.ANTHROPIC_API_KEY,
+        google: process.env.GOOGLE_AI_API_KEY,
+      };
+      return map[provider] ?? null;
+    },
+  }
+);
+
+export { keys };
+```
+
+This gives you the routing engine (BYOK → fallback chain → platform key) without a network call. You can migrate to the HTTP resolve path later when you want dashboard-managed routes and policies.
+
+### You'll see
+
+The same `ResolveResult` shape (`{ provider, model, source, keyId }`) but resolved locally.
+
+### How to test
+
+```ts
+const result = await keys.resolve('openai', 'gpt-4o');
+console.log(result);
+// { provider: 'openai', model: 'gpt-4o', source: 'platform' }
+```
+
+> **Tip**
+> You can start with local resolve (this step) and switch to HTTP resolve (Step 2.3) later when you're ready to use dashboard-managed routes and policies. The `resolveProvider` wrapper from Step 2.4 makes this a one-line change.
+
+### Build-agent prompt: create-local-resolve
+
+**Context docs** (adapt for your project): this page §2.6; `@restormel/keys` package (createKeys, provider definitions).
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Create a local Restormel Keys instance for in-process resolve (no HTTP call), as an alternative or precursor to the HTTP resolve client.
+>
+> **Steps:**
+>
+> 1. Create `src/lib/server/restormel-local.ts` (or equivalent).
+> 2. Import `createKeys` and the provider definitions you need (`openaiProvider`, `anthropicProvider`, `googleProvider`) from `@restormel/keys`.
+> 3. Configure `createKeys` with:
+>    - `routing.defaultProvider` set to your primary provider.
+>    - `routing.rules` set to your fallback order (array of provider IDs).
+>    - `getPlatformKey` that reads provider API keys from your existing env vars (e.g. `process.env.OPENAI_API_KEY`).
+> 4. Export the `keys` instance.
+> 5. In `src/lib/server/resolve-provider.ts`, add the local resolve as a third option:
+>    - If `USE_RESTORMEL_KEYS` and `USE_RESTORMEL_HTTP` (or similar flag): call HTTP resolve.
+>    - If `USE_RESTORMEL_KEYS` only: call `keys.resolve(provider, model)` locally.
+>    - Otherwise: legacy path.
+> 6. Verify: `keys.resolve('openai', 'gpt-4o')` returns `{ provider: 'openai', model: 'gpt-4o', source: 'platform' }` when `OPENAI_API_KEY` is set.
+>
+> **DO NOT:**
+> - Remove the HTTP resolve client from Step 2.3 — both paths should coexist.
+> - Hardcode real API keys. Read from env vars.
+> - Import UI packages (`@restormel/keys-svelte`, `@restormel/keys-react`) in server code.
+> - Commit real API keys or secrets.
+
+**Gate:** `keys.resolve()` returns a valid result with the correct provider and source. The feature flag still defaults to off. Both local and HTTP resolve paths are available.
+
+---
+
+## Checkpoint
+
+You now have:
+
+- A typed resolve client that calls the Restormel API (`src/lib/server/restormel.ts`).
+- (Optional) A local resolve instance using the `@restormel/keys` core (`src/lib/server/restormel-local.ts`).
+- A `resolveProvider` function that branches on the feature flag: Restormel path (with error fallback) or legacy path.
+- A test script (`scripts/test-resolve.ts`) that confirms the resolve endpoint works.
+- Error handling that falls back to legacy routing if Restormel is unreachable.
+
+Your app still defaults to the legacy routing path. You've confirmed the Restormel path works when the flag is on.
+
+**Next:** [Phase 3 — Add routes and fallbacks](/keys/docs/walkthrough/phase-3-routes) — configure multi-step routing in the dashboard so Restormel can fail over between providers automatically.

--- a/docs/walkthrough/05-phase-3-routes.md
+++ b/docs/walkthrough/05-phase-3-routes.md
@@ -1,0 +1,340 @@
+# Phase 3 — Add Routes and Fallbacks
+
+> **Time:** ~20 minutes
+> **Prerequisites:** [Phase 2](/keys/docs/walkthrough/phase-2-resolve) complete (resolve client works, feature flag wired)
+> **You'll need:** Access to the [Dashboard](/keys/dashboard), your project and environment from Phase 1
+
+This phase moves your routing decisions from "Restormel picks the default provider" to "Restormel evaluates a named route with multiple steps and fails over automatically." By the end, you have a fallback chain configured in the dashboard, and your resolve call returns results shaped by that chain.
+
+---
+
+## Step 3.1 — Understand routes and steps
+
+A **route** is a named routing configuration inside your project. It contains one or more **steps**, evaluated in order. Each step specifies a provider preference and an optional model. The **route mode** controls how steps are evaluated.
+
+```text
+Route: "ingestion"
+Mode:  fallback_chain
+
+  Step 1 → OpenAI   (gpt-4o)       → try first
+  Step 2 → Anthropic (claude-sonnet) → if step 1 fails
+  Step 3 → Google    (gemini-2.5-pro) → if step 2 fails
+```
+
+When your backend calls resolve with `routeId: "ingestion"`, Restormel walks the chain. If the first step's provider has a valid key and is not blocked by a policy, it's returned. If not (no key, rate-limited, deprecated), Restormel tries the next step.
+
+Route modes available:
+
+| Mode | Behaviour |
+|------|-----------|
+| `fallback_chain` | Try steps in order; return the first that resolves successfully |
+| `user_preferred` | Use the user's preferred provider if a BYOK key exists, then fall back to the chain |
+
+You can create multiple routes per project — for example, `ingestion` for background jobs and `interactive` for user-facing requests with different fallback priorities.
+
+---
+
+## Step 3.2 — Create your first route in the Dashboard
+
+> **Dashboard**
+> Your project → **Routes** → **Create route**.
+
+1. **Name:** Give the route a descriptive name (e.g. `ingestion`, `chat`, `interactive`). This becomes the `routeId` you pass to resolve.
+2. **Route mode:** Select `fallback_chain`.
+3. **Save** the route.
+
+At the moment, the dashboard UI shows steps but does not yet provide a full step editor. You create steps via the Steps API in Step 3.4a.
+
+Adjust provider order and models to match your actual preferences. The example above is illustrative.
+
+### You'll see
+
+The route detail page in the dashboard showing your named route, mode, and the steps in order. Each step shows the provider, model, and fallback condition.
+
+### How to test
+
+No code change yet. Confirm the route appears in the dashboard and the steps are in the correct order.
+
+---
+
+## Step 3.3 — Resolve with the route ID
+
+Update your resolve call to specify the route. This tells Restormel to evaluate that route's fallback chain instead of the project default.
+
+**curl test:**
+
+```bash
+curl -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "ingestion" }'
+```
+
+**In your resolve client (update the call site):**
+
+```ts
+// src/lib/server/resolve-provider.ts — updated
+const result = await restormelResolve({
+  environmentId: process.env.RESTORMEL_ENVIRONMENT_ID ?? 'production',
+  routeId: 'ingestion',  // ← specify the route
+});
+```
+
+> **Tip**
+> You can make the `routeId` configurable per call site. For example, your ingestion pipeline passes `routeId: 'ingestion'` while your chat handler passes `routeId: 'interactive'`. This lets different parts of your app have different fallback strategies.
+
+### You'll see
+
+The resolve response now reflects the route's first available step:
+
+```json
+{
+  "data": {
+    "routeId": "route_123",
+    "providerType": "openai",
+    "modelId": "gpt-4o",
+    "explanation": "route=route_123 step=0 provider=openai model=gpt-4o"
+  }
+}
+```
+
+The `data.routeId` matches the route you created. The `data.providerType` and `data.modelId` match the first enabled step.
+
+### How to test
+
+```bash
+# Should return the first step's provider
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "ingestion" }' \
+  | jq '.data.providerType, .data.modelId'
+```
+
+Expected output: `"openai"` and `"gpt-4o"` (or whatever your first step is).
+
+---
+
+## Step 3.4 — Test fallback behaviour
+
+To confirm the fallback chain works, make the first step unusable and confirm resolve returns the next enabled step. The dashboard UI shows steps; you create and manage steps via the Steps API (or the dashboard when a full step editor is available).
+
+### Step 3.4a — Create steps via the Steps API
+
+You need the route's internal ID (from the dashboard URL when viewing the route). Then create steps:
+
+```bash
+ROUTE_ID="route_123"  # copy from dashboard route detail URL
+
+# Step 1: OpenAI gpt-4o
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/routes/${ROUTE_ID}/steps" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "orderIndex": 0, "providerPreference": "openai", "modelId": "gpt-4o", "fallbackOn": "error", "enabled": true }'
+
+# Step 2: Anthropic
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/routes/${ROUTE_ID}/steps" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "orderIndex": 1, "providerPreference": "anthropic", "modelId": "claude-sonnet-4-20250514", "fallbackOn": "error", "enabled": true }'
+```
+
+### Step 3.4b — Disable the first step and re-resolve
+
+Temporarily disable (or delete) the first step so resolve returns the second step. Then call resolve again with the same route.
+
+> **Tip**
+> If you do not yet have a step update endpoint, deleting the first step is the simplest way to force the fallback path; re-create it afterwards.
+
+### You'll see
+
+The resolve response now returns the **second** step's provider:
+
+```json
+{
+  "data": {
+    "routeId": "route_123",
+    "providerType": "anthropic",
+    "modelId": "claude-sonnet-4-20250514",
+    "explanation": "route=route_123 step=1 provider=anthropic model=claude-sonnet-4-20250514"
+  }
+}
+```
+
+Restormel skipped the first step (no valid OpenAI key) and fell through to Anthropic.
+
+### How to test
+
+```bash
+# After removing the OpenAI credential
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "ingestion" }' \
+  | jq '.data.providerType'
+```
+
+Expected: `"anthropic"` (or your second step's provider).
+
+Re-enable (or re-create) the first step after testing.
+
+> **Pitfall**
+> If you want route resolution to depend on which platform keys are present in your app’s environment, use local resolve (Phase 2, Step 2.6) and implement `getPlatformKey`. The dashboard does not accept raw provider API keys today; it uses Provider Integrations (credential references).
+
+
+---
+
+## Step 3.5 — Wire route IDs into your application
+
+Now that routes work, make the route ID configurable in your resolve wrapper so different parts of your app can use different routes.
+
+```ts
+// src/lib/server/resolve-provider.ts — updated signature
+
+export async function resolveProvider(
+  options?: {
+    routeId?: string;
+    model?: string;
+  }
+): Promise<ProviderDecision> {
+  if (USE_RESTORMEL_KEYS) {
+    try {
+      const result = await restormelResolve({
+        environmentId: process.env.RESTORMEL_ENVIRONMENT_ID ?? 'production',
+        routeId: options?.routeId,
+      });
+      return {
+        provider: result.data.providerType ?? (process.env.DEFAULT_AI_PROVIDER ?? 'openai'),
+        model: result.data.modelId ?? options?.model ?? null,
+        source: 'restormel',
+      };
+    } catch (err) {
+      console.error('[restormel] Resolve failed, falling back to legacy:', err);
+    }
+  }
+
+  return legacyResolve(options?.model);
+}
+```
+
+Call sites become:
+
+```ts
+// Ingestion pipeline
+const decision = await resolveProvider({ routeId: 'ingestion' });
+
+// Chat handler
+const decision = await resolveProvider({ routeId: 'interactive', model: userSelectedModel });
+```
+
+### You'll see
+
+No visible change yet (the flag is still off by default). When you test with the flag on, different call sites resolve through different routes.
+
+### How to test
+
+```bash
+USE_RESTORMEL_KEYS=true pnpm dev
+# Trigger an ingestion job — should resolve via the 'ingestion' route
+# Trigger a chat request — should resolve via the 'interactive' route (if you created one)
+```
+
+### Build-agent prompt: wire-route-ids
+
+**Context docs** (adapt paths for your project): this page; Phase 2 (resolve client and feature flag wrapper).
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Update the resolve wrapper to accept a `routeId` parameter so different parts of your app use different routes, then update all call sites.
+>
+> **Steps:**
+>
+> 1. Open `src/lib/server/resolve-provider.ts` (or equivalent — the file with the `resolveProvider` function from Phase 2).
+> 2. Update the function signature to accept `options?: { routeId?: string; model?: string }` instead of (or in addition to) a bare `preferredModel` parameter.
+> 3. Pass `options.routeId` through to `restormelResolve({ environmentId, routeId: options.routeId, model: options.model })`.
+> 4. Read the routing inventory (`docs/restormel-integration/00-routing-inventory.md`) to identify every call site that resolves a provider.
+> 5. Update each call site to pass an appropriate `routeId`:
+>    - Background jobs / ingestion → `{ routeId: 'ingestion' }`
+>    - User-facing chat / interactive → `{ routeId: 'interactive' }` (or `'chat'`, matching your dashboard route name)
+>    - If only one route exists, all call sites can pass the same `routeId` or omit it (project default).
+> 6. If different call sites need different routes, create the additional routes in the Dashboard (Routes → Create route) with appropriate steps.
+> 7. Verify: with `USE_RESTORMEL_KEYS=true`, each call site resolves through its intended route.
+>
+> **DO NOT:**
+> - Change the legacy path. It should still work when the flag is off.
+> - Hardcode route IDs that don't exist in the dashboard. Create the route first, then reference it.
+> - Remove the error handling / legacy fallback from Phase 2.
+> - Commit real API keys or secrets.
+
+**Gate:** Each call site passes a `routeId`. With the flag on, resolve returns the correct route's provider/model. With the flag off, the app behaves identically to before. Fallback works (remove a provider credential → resolve returns the next step's provider).
+
+---
+
+## Step 3.6 — (Optional) Create a second route for different use cases
+
+If your app has distinct AI call patterns — for example, fast-and-cheap for autocomplete vs. powerful-and-expensive for analysis — create separate routes with different step orders and models.
+
+**Example: `autocomplete` route**
+
+| Step | Provider | Model | Fallback on |
+|------|----------|-------|-------------|
+| 1 | OpenAI | `gpt-4o-mini` | error |
+| 2 | Google | `gemini-2.0-flash` | error |
+
+**Example: `analysis` route**
+
+| Step | Provider | Model | Fallback on |
+|------|----------|-------|-------------|
+| 1 | Anthropic | `claude-sonnet-4-20250514` | error |
+| 2 | OpenAI | `gpt-4o` | error |
+| 3 | Google | `gemini-2.5-pro` | error |
+
+Create both in the Dashboard, then use the appropriate `routeId` in each call site.
+
+### You'll see
+
+Two (or more) routes in the dashboard, each with their own step order. Resolve calls with different `routeId` values return different providers.
+
+### How to test
+
+```bash
+# Resolve with autocomplete route
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "autocomplete" }' \
+  | jq '.data.providerType, .data.modelId'
+# Expected: "openai", "gpt-4o-mini"
+
+# Resolve with analysis route
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "analysis" }' \
+  | jq '.data.providerType, .data.modelId'
+# Expected: "anthropic", "claude-sonnet-4-20250514"
+```
+
+---
+
+## Checkpoint
+
+You now have:
+
+- At least one named route in the Restormel Dashboard with multiple steps (fallback chain).
+- Your resolve client passes a `routeId` so different parts of your app use different routing strategies.
+- Fallback verified: removing a provider credential causes Restormel to return the next step's provider.
+- (Optional) Multiple routes for different use cases (fast/cheap vs. powerful/expensive).
+
+The feature flag is still off by default. When on, your app resolves through Restormel routes.
+
+**Next:** [Phase 4 — Apply policies](/keys/docs/walkthrough/phase-4-policies) — add guardrails that constrain resolution (model allowlists, deprecation blocks, budget caps).

--- a/docs/walkthrough/06-phase-4-policies.md
+++ b/docs/walkthrough/06-phase-4-policies.md
@@ -1,0 +1,264 @@
+# Phase 4 — Apply Policies
+
+> **Time:** ~15 minutes
+> **Prerequisites:** [Phase 3](/keys/docs/walkthrough/phase-3-routes) complete (at least one route with steps configured, resolve returns route-aware results)
+> **You'll need:** Access to the [Dashboard](/keys/dashboard), your project from Phase 1
+
+This phase adds guardrails around resolution. Policies constrain which models and providers can be returned, block deprecated models, and cap spend. By the end, your resolve calls are filtered through policies before returning a result, and you can test that policy violations are correctly rejected.
+
+---
+
+## Step 4.1 — Understand policy types
+
+Policies are rules attached at the workspace, project, or environment level. They are evaluated during every resolve call. If a policy blocks the resolved model or provider, Restormel falls through to the next step in the route (or returns an error if no step passes).
+
+| Policy type | What it does | Example |
+|-------------|-------------|---------|
+| `model_allowlist` | Only these models can be resolved | Allow `gpt-4o`, `claude-sonnet-4-20250514`, block everything else |
+| `model_denylist` | These specific models are blocked | Block `gpt-3.5-turbo` (too old for your use case) |
+| `provider_allowlist` | Only these providers can be resolved | Allow `openai` and `anthropic`, block `google` |
+| `provider_denylist` | These specific providers are blocked | Block a provider with a compliance issue |
+| `deprecated_model_block` | Block models marked as deprecated in the Restormel model catalog | Prevent resolution to models approaching end-of-life |
+| `budget_cap` | Cap total spend per period | Max $500/month per environment |
+| `token_cap` | Cap total tokens per period | Max 10M tokens/month |
+
+Policies stack. If you have both a `model_allowlist` and a `budget_cap`, both must pass for a model to be resolved.
+
+---
+
+## Step 4.2 — Create a model allowlist
+
+Start with the most common policy: restricting which models your app can use.
+
+> **Dashboard**
+> Your project → **Policies** → **Create policy**.
+
+1. **Type:** `model_allowlist`
+2. **Scope:** Project (applies to all environments and routes in this project)
+3. **Models:** Add the models you want to allow. For example:
+   - `gpt-4o`
+   - `gpt-4o-mini`
+   - `claude-sonnet-4-20250514`
+   - `gemini-2.5-pro`
+4. **Save** the policy.
+
+### You'll see
+
+The policy listed on the project's Policies page with the type, scope, and allowed models.
+
+### How to test
+
+Call resolve requesting a model that is **not** on the allowlist:
+
+```bash
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "ingestion" }' \
+  | jq '.'
+```
+
+**Expected:** The resolve returns `data.modelId` from the first enabled step that passes policies. If your route steps include a blocked model, resolve skips that step and returns the next allowed step.
+
+> **Tip**
+> The resolve endpoint does not take an arbitrary `model` override today. To test allowlisting deterministically, set a route step’s `modelId` to a blocked model, then confirm resolve skips it.
+
+
+Call resolve with an allowed model:
+
+```bash
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "ingestion" }' \
+  | jq '.data.modelId'
+```
+
+**Expected:** One of your allowed models (e.g. `"gpt-4o"`).
+
+---
+
+## Step 4.3 — Add a deprecated-model block
+
+This policy prevents your app from resolving to models that the Restormel model catalog has marked as approaching end-of-life. It's a safety net: even if a route step specifies a deprecated model, this policy blocks it and forces a fallback.
+
+> **Dashboard**
+> Your project → **Policies** → **Create policy**.
+
+1. **Type:** `deprecated_model_block`
+2. **Scope:** Project
+3. **Save.** No additional configuration needed — the policy reads deprecation status from the model catalog automatically.
+
+### You'll see
+
+The policy listed on the Policies page. Its effect depends on whether any models in your routes are actually deprecated in the catalog.
+
+### How to test
+
+If you have a route step that specifies a model currently marked as deprecated, resolve should skip that step. If none of your models are deprecated, this policy has no visible effect yet — but it protects you when providers deprecate models in the future.
+
+To verify the policy is active, use the **evaluate** endpoint:
+
+> **Security**
+> `/api/policies/*` endpoints are workspace-scoped and do **not** accept a project Gateway Key. Use a **Management Key** for server-to-server checks, or test from the dashboard UI (session cookie).
+
+```bash
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/policies/evaluate" \
+  -H "Authorization: Bearer ${RESTORMEL_MANAGEMENT_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectId": "'${RESTORMEL_PROJECT_ID}'",
+    "environmentId": "production",
+    "modelId": "gpt-4-0314",
+    "providerType": "openai"
+  }' \
+  | jq '.data'
+```
+
+**Expected:** `data.allowed` is `false` when the model/provider combination is blocked by policies; `data.violations` explains why.
+
+> **Tip**
+> The evaluate endpoint is useful for testing policies without actually resolving. It tells you "would this model/provider combination pass all policies?" without executing a full route evaluation.
+
+---
+
+## Step 4.4 — Add a budget cap
+
+Budget caps prevent unexpected spend. When the cap is reached for a period, resolve returns an error rather than allowing more requests.
+
+> **Dashboard**
+> Your project → **Policies** → **Create policy**.
+
+1. **Type:** `budget_cap`
+2. **Scope:** Environment (`production`)
+3. **Limit:** Set a monthly limit in USD (e.g. `500`)
+4. **Period:** `monthly`
+5. **Save.**
+
+### You'll see
+
+The policy listed with the cap amount and period. Current spend tracking appears in the project's usage section.
+
+### How to test
+
+Budget caps take effect as usage accumulates. For immediate testing, set a very low cap (e.g. `$0.01`) and make a few resolve calls with tracked usage. Then call resolve again — it should fail with a budget error.
+
+**Restore the cap to a realistic value after testing.**
+
+> **Pitfall**
+> Budget caps depend on usage tracking. The dashboard resolve endpoint logs resolutions, but it does not automatically know the cost of your provider call unless you also report usage back to Restormel. Until usage reporting is part of your integration, treat `budget_cap` as a config you can create and bind, and validate it primarily via evaluate and later via usage reporting.
+
+---
+
+## Step 4.5 — Test policy stacking
+
+Policies stack: all active policies must pass for a model to be resolved. Verify this by having both a `model_allowlist` and a `deprecated_model_block` active, then evaluating a model that is on the allowlist but deprecated (if one exists).
+
+```bash
+curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/policies/evaluate" \
+  -H "Authorization: Bearer ${RESTORMEL_MANAGEMENT_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectId": "'${RESTORMEL_PROJECT_ID}'",
+    "environmentId": "production",
+    "modelId": "gpt-4o",
+    "providerType": "openai"
+  }' \
+  | jq '.data'
+```
+
+**Expected:** `gpt-4o` is on the allowlist and not deprecated → allowed. A model that's on the allowlist but deprecated → blocked by the deprecation policy.
+
+### You'll see
+
+The evaluate response shows which policies passed and which blocked.
+
+### How to test
+
+Test with several model/provider combinations to confirm the intersection of your policies behaves as expected.
+
+---
+
+## Step 4.6 — Handle policy errors in your resolve wrapper
+
+When all route steps are blocked by policies, Restormel returns an error. Your resolve wrapper (from Phase 2) already catches errors and falls back to legacy. Add specific handling for policy errors so you can log or alert on them.
+
+```ts
+// src/lib/server/resolve-provider.ts — updated error handling
+
+try {
+  const result = await restormelResolve({
+    environmentId: process.env.RESTORMEL_ENVIRONMENT_ID ?? 'production',
+    routeId: options?.routeId,
+  });
+  return {
+    provider: result.data.providerType ?? (process.env.DEFAULT_AI_PROVIDER ?? 'openai'),
+    model: result.data.modelId ?? options?.model ?? null,
+    source: 'restormel',
+  };
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (message.includes('budget') || message.includes('cap')) {
+    console.error('[restormel] Budget cap reached:', message);
+    // Optionally: alert, notify, or return a specific error to the user
+  } else if (message.includes('no_key_available')) {
+    console.warn('[restormel] No provider key available for route');
+  } else {
+    console.error('[restormel] Resolve failed:', message);
+  }
+
+  // Fall through to legacy
+}
+```
+
+### Build-agent prompt: add-policies-and-error-handling
+
+**Context docs** (adapt paths for your project): this page (policy types, evaluate endpoint, error handling); Phase 2 (resolve client and error handling).
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Update the resolve error handling to distinguish policy errors (budget cap, model blocked) from network/auth errors, and add appropriate logging or user-facing responses.
+>
+> **Steps:**
+>
+> 1. Open `src/lib/server/resolve-provider.ts` (or equivalent).
+> 2. In the `catch` block for the Restormel resolve call, parse the error message for known policy error patterns:
+>    - `budget` or `cap` → budget cap reached (log as error, optionally return a user-friendly "quota exceeded" response).
+>    - `no_key_available` → no provider could be resolved (log as warning).
+>    - `deprecated` or `blocked` → model blocked by policy (log as warning).
+>    - Anything else → generic resolve failure (log as error).
+> 3. For budget cap errors, optionally add an alert mechanism (e.g. send a notification, emit a metric) so you're notified before production requests start failing.
+> 4. For all policy errors, the function still falls through to the legacy path (existing behaviour from Phase 2).
+> 5. Add a comment in the code referencing the policy types and evaluate endpoint for future maintainers.
+> 6. Verify: with `USE_RESTORMEL_KEYS=true` and a low budget cap set in the dashboard, the budget error is caught and logged, and the legacy fallback runs.
+>
+> **DO NOT:**
+> - Change the legacy fallback logic.
+> - Remove the generic error handling from Phase 2.
+> - Expose raw Restormel error messages to end-users. Translate them into user-friendly messages.
+> - Commit real API keys or secrets.
+
+**Gate:** Policy errors (budget, blocked model) are logged distinctly from generic errors. The legacy fallback still runs on any Restormel failure. No raw error details leak to end-users.
+
+---
+
+## Checkpoint
+
+You now have:
+
+- A `model_allowlist` policy constraining which models can be resolved.
+- A `deprecated_model_block` policy preventing resolution to end-of-life models.
+- (Optional) A `budget_cap` policy limiting spend per environment per period.
+- Policy error handling in your resolve wrapper that distinguishes budget, blocked, and generic errors.
+- The evaluate endpoint as a tool for testing policy combinations without executing a full resolve.
+
+Policies are active on the Restormel side. Your app handles policy errors gracefully and falls back to legacy when needed.
+
+**Next:** [Phase 5 — Embed the UI](/keys/docs/walkthrough/phase-5-ui) — add ModelSelector and KeyManager to your app so end-users can choose models and manage their own provider credentials.

--- a/docs/walkthrough/07-phase-5-ui.md
+++ b/docs/walkthrough/07-phase-5-ui.md
@@ -1,0 +1,410 @@
+# Phase 5 — Embed the UI
+
+> **Time:** ~25 minutes
+> **Prerequisites:** [Phase 4](/keys/docs/walkthrough/phase-4-policies) complete (routes and policies configured, resolve works with route IDs)
+> **You'll need:** Your app's frontend codebase, the UI packages installed in Phase 1
+
+This phase puts Restormel's embeddable components into your app so end-users can select models and (optionally) manage their own provider credentials. By the end, your app shows a ModelSelector filtered by your policies and a KeyManager for BYOK, both wired to your backend.
+
+---
+
+## Step 5.1 — Decide what to embed
+
+Not every app needs every component. Use this decision matrix:
+
+| If your app… | Embed | Skip |
+|-------------|-------|------|
+| Lets users choose which AI model to use | **ModelSelector** | — |
+| Lets users bring their own provider API keys (BYOK) | **KeyManager** | — |
+| Shows cost estimates before running a request | **CostEstimator** | — |
+| Only uses platform keys with no user choice | — | All UI components (server-side resolve is enough) |
+
+Most apps that reached this phase want **ModelSelector**. **KeyManager** is for apps where users supply their own OpenAI/Anthropic/Google keys. **CostEstimator** is a nice-to-have.
+
+---
+
+## Step 5.2 — Embed ModelSelector (Next.js / React)
+
+**`app/settings/page.tsx`** (server component):
+
+```tsx
+// app/settings/page.tsx
+import { KeysProvider } from '@restormel/keys-react';
+import { openaiProvider, anthropicProvider, googleProvider } from '@restormel/keys';
+import { ModelSelectorClient } from './ModelSelectorClient';
+
+export default function SettingsPage() {
+  const config = { keys: [], routing: { defaultProvider: 'openai' } };
+  const options = { providers: [openaiProvider, anthropicProvider, googleProvider] };
+
+  return (
+    <KeysProvider config={config} options={options}>
+      <h1>Model settings</h1>
+      <ModelSelectorClient />
+    </KeysProvider>
+  );
+}
+```
+
+**`app/settings/ModelSelectorClient.tsx`** (client component):
+
+```tsx
+// app/settings/ModelSelectorClient.tsx
+'use client';
+
+import { ModelSelector, useKeysContext } from '@restormel/keys-react';
+import { openaiProvider, anthropicProvider, googleProvider } from '@restormel/keys';
+
+export function ModelSelectorClient() {
+  const { keys } = useKeysContext();
+
+  function handleSelect(modelId: string, providerId: string) {
+    // Save the user's model preference to your backend
+    fetch('/api/preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ modelId, providerId }),
+    });
+  }
+
+  return (
+    <ModelSelector
+      keys={keys}
+      providers={[openaiProvider, anthropicProvider, googleProvider]}
+      onSelect={handleSelect}
+    />
+  );
+}
+```
+
+> **Tip**
+> Use `next/dynamic` with `ssr: false` to lazy-load the model selector so it doesn't increase your initial page bundle.
+
+```tsx
+import dynamic from 'next/dynamic';
+const ModelSelectorClient = dynamic(() => import('./ModelSelectorClient'), { ssr: false });
+```
+
+### You'll see
+
+A model selection UI grouped by provider. Each model shows its availability based on whether a key exists for that provider. Users click a model to select it.
+
+### How to test
+
+1. Start your dev server: `pnpm dev`
+2. Navigate to `/settings` (or wherever you embedded the component).
+3. Confirm the ModelSelector renders with provider groups and models.
+4. Click a model. Confirm the `onSelect` callback fires (check your network tab for the `POST /api/preferences` call).
+
+---
+
+## Step 5.3 — Embed ModelSelector (SvelteKit)
+
+```svelte
+<!-- src/routes/settings/+page.svelte -->
+<script lang="ts">
+  import { ModelSelector } from '@restormel/keys-svelte';
+  import { createKeys, openaiProvider, anthropicProvider, googleProvider } from '@restormel/keys';
+
+  const keys = createKeys(
+    { keys: [], routing: { defaultProvider: 'openai' } },
+    { providers: [openaiProvider, anthropicProvider, googleProvider] }
+  );
+
+  const providers = [openaiProvider, anthropicProvider, googleProvider];
+
+  function handleSelect(modelId: string, providerId: string) {
+    fetch('/api/preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ modelId, providerId }),
+    });
+  }
+</script>
+
+<h1>Model settings</h1>
+<ModelSelector {keys} {providers} onSelect={handleSelect} />
+```
+
+### You'll see
+
+The same model selection UI as the React version, rendered natively in Svelte.
+
+### How to test
+
+Same as Step 5.2: navigate to the settings page, confirm rendering, click a model, verify the callback.
+
+---
+
+## Step 5.4 — Embed ModelSelector (Web Components / vanilla)
+
+For frameworks not covered by the React or Svelte wrappers, use the Web Components directly:
+
+```html
+<!-- In your HTML or template -->
+<script type="module">
+  import '@restormel/keys-elements';
+  import { createKeys, openaiProvider, anthropicProvider, googleProvider } from '@restormel/keys';
+
+  const keys = createKeys(
+    { keys: [], routing: { defaultProvider: 'openai' } },
+    { providers: [openaiProvider, anthropicProvider, googleProvider] }
+  );
+
+  const el = document.querySelector('rk-model-selector');
+  el.keys = keys;
+  el.providers = [openaiProvider, anthropicProvider, googleProvider];
+
+  el.addEventListener('rk-model-selected', (e) => {
+    const { modelId, providerId } = e.detail;
+    fetch('/api/preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ modelId, providerId }),
+    });
+  });
+</script>
+
+<rk-model-selector></rk-model-selector>
+```
+
+> **Pitfall**
+> Web Components require setting object props (`keys`, `providers`) via JavaScript properties, not HTML attributes. HTML attributes only work for primitives like `user-id`. See [Framework compatibility](/keys/docs/compatibility) for the full list.
+
+### You'll see
+
+The model selector rendered inside a shadow DOM. Theming applies via `--rk-*` CSS custom properties on the element or a parent.
+
+### How to test
+
+Open your page in a browser. Confirm the custom element renders. Click a model. Confirm the `rk-model-selected` event fires (check via the event listener's console log or network request).
+
+---
+
+## Step 5.5 — Filter the model list by policies
+
+The ModelSelector shows all models from the configured providers by default. If you have policies (Phase 4) that restrict which models are allowed, you should filter the model list so users only see valid choices.
+
+Two approaches:
+
+**A) Server-side filtering (recommended):** Fetch the allowed models from Restormel's evaluate or catalog API, then pass them to the component.
+
+```ts
+// app/api/allowed-models/route.ts (Next.js) or equivalent
+export async function GET() {
+  const allModels = ['gpt-4o', 'gpt-4o-mini', 'claude-sonnet-4-20250514', 'gemini-2.5-pro'];
+
+  const allowed = [];
+  for (const model of allModels) {
+    const res = await fetch(
+      `https://restormel.dev/keys/dashboard/api/policies/evaluate`,
+      {
+        method: 'POST',
+        headers: {
+          // Use a Management Key for policies (Gateway Keys do not have access to workspace-scoped policy APIs)
+          'Authorization': `Bearer ${process.env.RESTORMEL_MANAGEMENT_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          projectId: process.env.RESTORMEL_PROJECT_ID,
+          environmentId: 'production',
+          modelId: model,
+          providerType: 'openai', // evaluate per providerType if needed
+        }),
+      }
+    );
+    const result = await res.json();
+    if (result.data?.allowed) allowed.push(model);
+  }
+
+  return Response.json({ models: allowed });
+}
+```
+
+Then in your client component, fetch `/api/allowed-models` and only configure the providers/models that are allowed.
+
+> **Security**
+> Never call the policies API from the browser. Keep `RESTORMEL_MANAGEMENT_KEY` server-side only (e.g. in a route handler). Use a server proxy like `/api/allowed-models` and return only the filtered model IDs to the client.
+
+**B) Client-side filtering with entitlements:** If you use local resolve (Phase 2, Step 2.6), the `keys.entitlements` object can filter models:
+
+```ts
+const allModelIds = keys.getAllModelIds();
+const allowed = keys.entitlements.getAvailableModels(allModelIds);
+```
+
+### You'll see
+
+The ModelSelector shows only models that pass your policies. Blocked models are either hidden or shown as unavailable with a reason.
+
+### How to test
+
+Add a `model_allowlist` policy that excludes one model (e.g. block `gpt-3.5-turbo`). Refresh the settings page. That model should not appear (or should appear greyed out with "Not allowed").
+
+---
+
+## Step 5.6 — Embed KeyManager (optional — for BYOK apps)
+
+If your app lets end-users bring their own API keys, embed the KeyManager component. This provides a settings panel for users to add, validate, list, and remove their provider credentials.
+
+**Next.js / React:**
+
+```tsx
+// app/settings/KeyManagerClient.tsx
+'use client';
+
+import { KeyManager, useKeysContext } from '@restormel/keys-react';
+import { openaiProvider, anthropicProvider } from '@restormel/keys';
+
+export function KeyManagerClient({ userId }: { userId: string }) {
+  const { keys } = useKeysContext();
+
+  return (
+    <KeyManager
+      keys={keys}
+      userId={userId}
+      providers={[openaiProvider, anthropicProvider]}
+      onKeyAdded={(key, apiKey) => {
+        // Persist to your backend
+        fetch('/api/keys', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ provider: key.provider, label: key.label }),
+        });
+      }}
+      onKeyRemoved={(keyId) => {
+        fetch(`/api/keys/${keyId}`, { method: 'DELETE' });
+      }}
+    />
+  );
+}
+```
+
+**SvelteKit:**
+
+```svelte
+<script lang="ts">
+  import { KeyManager } from '@restormel/keys-svelte';
+  // ... keys instance and providers setup as in Step 5.3
+
+  function handleKeyAdded(key, apiKey) {
+    fetch('/api/keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: key.provider, label: key.label }),
+    });
+  }
+
+  function handleKeyRemoved(keyId) {
+    fetch(`/api/keys/${keyId}`, { method: 'DELETE' });
+  }
+</script>
+
+<KeyManager
+  {keys}
+  userId={$page.data.userId}
+  providers={[openaiProvider, anthropicProvider]}
+  onKeyAdded={handleKeyAdded}
+  onKeyRemoved={handleKeyRemoved}
+/>
+```
+
+> **Security**
+> The KeyManager validates keys client-side by making a lightweight test call to the provider. Raw key material is never sent to Restormel. Your backend should store only hashed keys and metadata (provider, label, key prefix). Use a secure server-side storage adapter; never log or expose raw keys.
+
+### You'll see
+
+A settings panel with:
+- An empty state prompting "Add your first API key."
+- A form to select a provider and paste a key.
+- Validation feedback (green check or red error).
+- A list of stored keys (masked, with provider icon and status).
+- Delete buttons for each key.
+
+### How to test
+
+1. Navigate to settings.
+2. Add a key (use a test/invalid key for now — validation will fail, which is expected).
+3. Confirm the `onKeyAdded` callback fires and your `/api/keys` endpoint receives the request.
+4. If you have a valid provider key, add it. Confirm validation passes (green indicator).
+5. Delete the key. Confirm `onKeyRemoved` fires and the key disappears from the list.
+
+---
+
+## Step 5.7 — Theme the components
+
+Restormel UI components use `--rk-*` CSS custom properties for theming. Override them to match your app's design:
+
+```css
+/* In your app's global CSS or a scoped stylesheet */
+rk-key-manager,
+rk-model-selector,
+rk-cost-estimator,
+.rk-key-manager,
+.rk-model-selector,
+.rk-cost-estimator {
+  --rk-bg: #1a1a1e;
+  --rk-text: #e8e8ec;
+  --rk-accent: #3b82f6;
+  --rk-border: #2a2a2e;
+  --rk-error: #ef4444;
+  --rk-success: #22c55e;
+}
+```
+
+The components ship with a dark theme (`.rk-dark`) and light theme (`.rk-light`) preset. The dark theme matches the Restormel dashboard aesthetic.
+
+### You'll see
+
+Components render with your app's colour scheme instead of the defaults.
+
+### How to test
+
+Change a token (e.g. `--rk-accent`) to something visually distinct (hot pink). Confirm the accent colour updates on buttons and highlights.
+
+### Build-agent prompt: embed-ui-components
+
+**Context docs** (adapt paths for your project): this page (embedding patterns for React, SvelteKit, Web Components); [Framework compatibility](/keys/docs/compatibility) (which package for which framework).
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Embed Restormel Keys UI components (ModelSelector and optionally KeyManager) into your app's settings page.
+>
+> **Steps:**
+>
+> 1. Read the routing inventory (`docs/restormel-integration/00-routing-inventory.md`) to identify the existing model picker and/or BYOK settings UI to replace.
+> 2. Based on your framework:
+>    - **Next.js/React:** Create a client component wrapping `ModelSelector` from `@restormel/keys-react` inside a `KeysProvider`. Use `next/dynamic` with `ssr: false` for the client component. See `packages/react/README.md` for the exact pattern.
+>    - **SvelteKit:** Import `ModelSelector` from `@restormel/keys-svelte` directly. Create the `keys` instance with `createKeys`.
+>    - **Web Components:** Import `@restormel/keys-elements`, set `keys` and `providers` as properties on the `<rk-model-selector>` element.
+> 3. Wire the `onSelect` callback (or `rk-model-selected` event) to save the user's model preference to your backend (e.g. `POST /api/preferences`).
+> 4. If BYOK is needed: embed `KeyManager` with `onKeyAdded` and `onKeyRemoved` callbacks wired to your key storage API (e.g. `POST /api/keys`, `DELETE /api/keys/:id`). Follow the KeyStorage adapter pattern from `docs/reference/sophia-integration.md`.
+> 5. Add `--rk-*` CSS overrides to match your app's theme. At minimum set `--rk-bg`, `--rk-text`, and `--rk-accent`.
+> 6. Handle all required states: loading (show skeleton), error (show message + retry), empty (show "Add your first key" or "No models available").
+> 7. Verify: components render, selection fires callbacks, theme applies, keyboard navigation works (Tab, Enter, Escape).
+>
+> **DO NOT:**
+> - Import UI packages in server-side code. All UI components are client-only.
+> - Log or expose raw API keys in the browser console, network tab, or error messages.
+> - Skip empty/error/loading states — they are required per `docs/ux-contracts.md`.
+> - Hardcode model lists. Read from the `keys` instance or fetch allowed models from your backend.
+> - Commit real API keys or secrets.
+
+**Gate:** ModelSelector renders and fires `onSelect` with modelId and providerId. (If BYOK) KeyManager renders, add/remove key callbacks work. Components respect `--rk-*` theme tokens. Loading, error, and empty states are handled. Keyboard navigation works (Tab through controls, Enter to select, Escape to close).
+
+---
+
+## Checkpoint
+
+You now have:
+
+- **ModelSelector** embedded in your app, showing models grouped by provider, filtered by your policies.
+- (Optional) **KeyManager** embedded for BYOK, with add/validate/list/remove flows wired to your backend.
+- Components themed to match your app's design via `--rk-*` CSS custom properties.
+- Callbacks wired so user selections are saved to your backend.
+
+The UI components work alongside your resolve integration from Phases 2–4. When a user selects a model, your backend can pass that selection to `resolveProvider({ model: userSelectedModel })` and Restormel evaluates it against routes and policies.
+
+**Next:** [Phase 6 — Go live](/keys/docs/walkthrough/phase-6-golive) — parallel run, cutover, and production verification.

--- a/docs/walkthrough/08-phase-6-golive.md
+++ b/docs/walkthrough/08-phase-6-golive.md
@@ -1,0 +1,255 @@
+# Phase 6 — Go Live
+
+> **Time:** ~30 minutes (cutover) + monitoring period
+> **Prerequisites:** [Phase 5](/keys/docs/walkthrough/phase-5-ui) complete (resolve, routes, policies, and UI all working with the feature flag on in development)
+> **You'll need:** Access to your deployment pipeline, monitoring/logging, the [Dashboard](/keys/dashboard)
+
+This phase moves your Restormel Keys integration from development into production traffic. The strategy is conservative: parallel run, phased traffic shift, verify, then cut over fully. By the end, your production app resolves through Restormel and the legacy routing code is retired.
+
+---
+
+## Step 6.1 — Pre-cutover checklist
+
+Before enabling the feature flag in production, verify everything works in a staging or preview environment.
+
+| Check | How to verify | Pass? |
+|-------|--------------|-------|
+| Resolve works | `USE_RESTORMEL_KEYS=true` in staging; make AI requests; confirm correct provider/model | ☐ |
+| Fallback works | Remove a provider credential in dashboard; confirm resolve returns next step | ☐ |
+| Policy enforcement works | Request a blocked model; confirm it's rejected or falls through | ☐ |
+| Error fallback works | Set invalid Gateway Key; confirm legacy routing takes over | ☐ |
+| ModelSelector renders | Open settings page; confirm component loads and selection works | ☐ |
+| (If BYOK) KeyManager works | Add/remove a test key; confirm callbacks fire | ☐ |
+| `keys doctor` passes | Run `npx @restormel/keys-cli doctor` in the staging env | ☐ |
+| `keys validate` passes | Run `npx @restormel/keys-cli validate` to re-check stored keys | ☐ |
+| No secrets committed | Run `scripts/check-secrets.sh` or `git log --diff-filter=A -- '*.env'` | ☐ |
+| Dashboard logs show requests | Check the project's usage/logs section in the dashboard | ☐ |
+
+> **Pitfall**
+> Do not skip the error fallback check. The most dangerous production failure mode is Restormel being unreachable and your app not falling back to legacy. Confirm this works before proceeding.
+
+---
+
+## Step 6.2 — Enable the flag for a small percentage (parallel run)
+
+If your app supports percentage-based rollout (e.g. via LaunchDarkly, Vercel Edge Config, Cloudflare Workers, or a simple random check), start with a small percentage of traffic using Restormel.
+
+```ts
+// src/lib/feature-flags.ts — updated for percentage rollout
+
+const RESTORMEL_ROLLOUT_PERCENT = parseInt(
+  process.env.RESTORMEL_ROLLOUT_PERCENT ?? '0',
+  10
+);
+
+export const USE_RESTORMEL_KEYS =
+  process.env.USE_RESTORMEL_KEYS === 'true' ||
+  (RESTORMEL_ROLLOUT_PERCENT > 0 && Math.random() * 100 < RESTORMEL_ROLLOUT_PERCENT);
+```
+
+**Rollout sequence:**
+
+| Step | `RESTORMEL_ROLLOUT_PERCENT` | What to watch |
+|------|-----------------------------|---------------|
+| 1 | `5` | Errors in logs, latency increase, correct provider in responses |
+| 2 | `25` | Same, at higher volume |
+| 3 | `50` | Compare Restormel path vs legacy path outcomes |
+| 4 | `100` | Full traffic through Restormel |
+
+If you don't have percentage-based rollout, use the boolean flag: `USE_RESTORMEL_KEYS=true` for the full cutover (Step 6.3).
+
+### You'll see
+
+A mix of requests going through Restormel (your app logs should include `providerType` / `modelId` from resolve) and legacy (your existing logs). The ratio should roughly match your rollout percentage.
+
+### How to test
+
+Check your application logs. Requests that went through Restormel should log the resolved provider and source. Requests that went through legacy should log the legacy provider. Both should succeed without user-facing errors.
+
+---
+
+## Step 6.3 — Full cutover
+
+When you're confident from the parallel run, enable Restormel for all traffic:
+
+```bash
+# In your production environment variables
+USE_RESTORMEL_KEYS=true
+RESTORMEL_ROLLOUT_PERCENT=100  # if using percentage-based rollout
+```
+
+Deploy the env change. Monitor for 15–30 minutes.
+
+### You'll see
+
+All AI requests resolve through Restormel. Your logs should show the resolved `providerType` / `modelId` for every request. The dashboard shows request volume in the project's usage section.
+
+### How to test
+
+```bash
+# Verify no requests are going through legacy
+grep -c '"source":"legacy"' /path/to/your/app.log
+# Expected: 0 (or near-zero during the deployment window)
+```
+
+Check the dashboard: **Projects → your project → Usage**. You should see request counts matching your expected traffic.
+
+> **Tip**
+> Keep the legacy fallback code in place for at least one release cycle after cutover. If something unexpected happens, you can flip the flag back to `false` and instantly restore the old behaviour.
+
+---
+
+## Step 6.4 — Post-cutover verification
+
+Run a comprehensive check within the first hour after cutover.
+
+**CLI checks:**
+
+```bash
+# Doctor: confirm environment is healthy
+npx @restormel/keys-cli doctor
+
+# Validate: re-check all stored keys
+npx @restormel/keys-cli validate
+```
+
+**Dashboard checks:**
+
+1. **Usage:** Request count is non-zero and growing. No unexpected error spikes.
+2. **Routes:** The routes you configured show traffic against them.
+3. **Policies:** No unexpected policy violations (unless you've intentionally blocked something).
+4. **Provider credentials:** All credentials show "valid" status.
+
+**Application checks:**
+
+1. Make a request through each major code path (ingestion, chat, etc.). Confirm correct provider and model.
+2. Test fallback: temporarily remove a provider credential in the dashboard. Confirm your app uses the next step. Restore the credential.
+3. Test a policy block: request a model not on your allowlist. Confirm it's rejected or falls back.
+4. Check latency: compare request latency before and after cutover. The resolve call adds a network round-trip (typically <100ms). If latency is unacceptable, consider switching to local resolve (Phase 2, Step 2.6).
+
+**Smoke test script:**
+
+```bash
+#!/bin/bash
+# scripts/smoke-test-restormel.sh
+
+echo "=== Restormel smoke test ==="
+
+# 1. Resolve
+echo "1. Resolve..."
+RESULT=$(curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "ingestion" }')
+echo "   Provider: $(echo $RESULT | jq -r '.data.providerType')"
+echo "   Model: $(echo $RESULT | jq -r '.data.modelId')"
+echo "   Explanation: $(echo $RESULT | jq -r '.data.explanation')"
+
+# 2. Policy evaluate
+echo "2. Policy evaluate (allowed model)..."
+EVAL=$(curl -s -X POST \
+  "https://restormel.dev/keys/dashboard/api/policies/evaluate" \
+  -H "Authorization: Bearer ${RESTORMEL_MANAGEMENT_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "projectId": "'${RESTORMEL_PROJECT_ID}'", "environmentId": "production", "modelId": "gpt-4o", "providerType": "openai" }')
+echo "   Result: $(echo $EVAL | jq '.data')"
+
+# 3. CLI doctor
+echo "3. keys doctor..."
+npx @restormel/keys-cli doctor
+
+echo "=== Done ==="
+```
+
+### Build-agent prompt: create-smoke-test
+
+**Context docs** (adapt paths for your project): this page (smoke test script, post-cutover checks); [Phase 2 — Resolve](/keys/docs/walkthrough/phase-2-resolve) (resolve endpoint and auth); [Phase 4 — Policies](/keys/docs/walkthrough/phase-4-policies) (evaluate endpoint).
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Create a post-cutover smoke test script that verifies Restormel Keys is working in production.
+>
+> **Steps:**
+>
+> 1. Create `scripts/smoke-test-restormel.sh` (bash, executable).
+> 2. The script must:
+>    a. Call the resolve endpoint with your production project ID and environment. Print the resolved provider, model, and source.
+>    b. Call the policy evaluate endpoint with an allowed model. Print whether it's allowed.
+>    c. Call the policy evaluate endpoint with a blocked model (if one exists). Print whether it's blocked.
+>    d. Run `npx @restormel/keys-cli doctor` and print the result.
+>    e. Run `npx @restormel/keys-cli validate` and print the result.
+>    f. Exit with code 0 if all checks pass, 1 if any fail.
+> 3. The script reads `RESTORMEL_GATEWAY_KEY`, `RESTORMEL_PROJECT_ID`, and `RESTORMEL_ENVIRONMENT_ID` from the environment. It must not contain hardcoded secrets.
+> 4. Add the script to `package.json` scripts: `"smoke:restormel": "bash scripts/smoke-test-restormel.sh"`.
+> 5. Verify: the script runs in your staging environment and exits 0.
+>
+> **DO NOT:**
+> - Hardcode real API keys, project IDs, or URLs in the script.
+> - Make the script destructive (no data modification, no key deletion).
+> - Skip the doctor/validate checks — they catch drift.
+> - Commit real API keys or secrets.
+
+**Gate:** `pnpm run smoke:restormel` exits 0 in staging. The script prints resolved provider, policy evaluation results, and doctor/validate output. No secrets are hardcoded.
+
+---
+
+## Step 6.5 — Remove legacy routing code
+
+Once you're confident Restormel is handling all traffic correctly (at least one full release cycle with the flag at 100%), clean up:
+
+1. **Remove the feature flag.** The Restormel path is now the only path.
+2. **Remove the legacy resolve function.** The `legacyResolve` fallback in `resolve-provider.ts` is no longer needed.
+3. **Remove the inventory items marked "REMOVE" in Phase 0.** Custom router, hardcoded model lists, custom fallback chains, custom model picker UI.
+4. **Remove unused env vars.** Any `DEFAULT_MODEL`, `AI_PROVIDER`, or provider-specific routing env vars that Restormel replaces.
+5. **Keep the error fallback to a sensible default.** Even without legacy code, your resolve wrapper should handle Restormel errors gracefully (e.g. return a hardcoded default provider/model or a user-facing error).
+
+### Build-agent prompt: remove-legacy-routing
+
+**Context docs** (adapt paths for your project): this page (Step 6.5 removal scope); [Phase 0 — Inventory](/keys/docs/walkthrough/phase-0-inventory) (the "REMOVE" items); [Phase 2 — Resolve](/keys/docs/walkthrough/phase-2-resolve) (resolve wrapper and feature flag to remove).
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Remove the legacy routing code now that Restormel Keys handles all provider resolution.
+>
+> **Steps:**
+>
+> 1. Read the routing inventory at `docs/restormel-integration/00-routing-inventory.md`. For every item marked "REMOVE," delete the file or the relevant code block.
+> 2. In `src/lib/server/resolve-provider.ts` (or equivalent):
+>    a. Remove the `USE_RESTORMEL_KEYS` feature flag import and conditional.
+>    b. Remove the `legacyResolve` function.
+>    c. The resolve function now always calls `restormelResolve`. Keep the try/catch but change the fallback from "legacy path" to "return a hardcoded safe default or throw a user-friendly error."
+> 3. Remove the feature flag module (`src/lib/feature-flags.ts`) if `USE_RESTORMEL_KEYS` was its only export.
+> 4. Remove `USE_RESTORMEL_KEYS` and `RESTORMEL_ROLLOUT_PERCENT` from `.env.example`.
+> 5. Remove any UI components marked "REMOVE" in the inventory (custom model picker, custom BYOK panel) that have been replaced by Restormel ModelSelector/KeyManager.
+> 6. Remove unused env vars from `.env.example` (e.g. `DEFAULT_MODEL`, `AI_PROVIDER`) if they were only used by the legacy routing.
+> 7. Run the full test suite. Fix any broken imports or references.
+> 8. Run `scripts/smoke-test-restormel.sh` to confirm everything still works.
+>
+> **DO NOT:**
+> - Remove billing, auth, session, or orchestration code (these are "KEEP" items).
+> - Remove the Restormel error handling (try/catch in resolveProvider). The app must still handle Restormel failures gracefully.
+> - Remove env vars that other parts of the app use (e.g. `OPENAI_API_KEY` if it's still used for direct provider calls outside of routing).
+> - Remove the smoke test script.
+> - Commit real API keys or secrets.
+
+**Gate:** All "REMOVE" items from the routing inventory are deleted. The feature flag is gone. `resolveProvider` always uses Restormel. Tests pass. Smoke test passes. No legacy routing code remains.
+
+---
+
+## Checkpoint
+
+You now have:
+
+- Production traffic resolving through Restormel Keys.
+- A smoke test script for ongoing verification.
+- (After Step 6.5) Legacy routing code removed; Restormel is the single source of truth.
+- Dashboard showing live traffic, route usage, and policy enforcement.
+
+Your integration is complete. For ongoing operations, see [Verification strategy](/keys/docs/walkthrough/verification-strategy).
+
+**Next:** [Migration paths](/keys/docs/walkthrough/migration-paths) — if you're coming from LiteLLM, Portkey, or OpenRouter instead of custom code, or want to see the strangler pattern in detail.

--- a/docs/walkthrough/09-migration-paths.md
+++ b/docs/walkthrough/09-migration-paths.md
@@ -1,0 +1,220 @@
+# Migration Paths
+
+> **Time:** Varies by source system
+> **Prerequisites:** Familiarity with your current routing system, a Restormel Keys account
+> **You'll need:** Access to your current gateway/proxy config, your app's codebase, and the [Dashboard](/keys/dashboard)
+
+This page covers migration from four starting points: custom routing code, LiteLLM, Portkey, and OpenRouter. Each variant follows the same principle: **strangler pattern** — run old and new in parallel, shift traffic incrementally, verify, then retire the old system.
+
+The walkthrough phases (0–6) are framework-agnostic. This page maps each migration source to the phases, highlights what's different, and provides source-specific prompts.
+
+---
+
+## Migration principle: the strangler pattern
+
+```mermaid
+graph LR
+    A["Your app"] -->|"100% traffic"| B["Old routing<br/>(LiteLLM / Portkey / custom)"]
+
+    A -->|"feature flag"| C{"Restormel<br/>resolve"}
+    C -->|"new path"| D["AI Provider"]
+    B -->|"old path"| D
+
+```
+
+1. **Install** Restormel Keys alongside your existing system (Phase 1). Nothing changes yet.
+2. **Wire** the resolve call behind a feature flag (Phase 2). Old system still handles 100%.
+3. **Shift** a small percentage of traffic to Restormel (Phase 6, Step 6.2). Both systems run.
+4. **Verify** — compare outcomes, latency, and errors between old and new paths.
+5. **Cut over** — move all traffic to Restormel. Old system is idle.
+6. **Remove** — decommission the old system after a burn-in period.
+
+At no point do you rip out the old system before the new one is proven. The feature flag (Phase 0, Step 0.5) is your safety net throughout.
+
+---
+
+## Variant A: "I have custom routing code"
+
+This is the default path the walkthrough is written for. Your app has bespoke `if/else`, config files, or a small routing module that picks providers.
+
+**What's different:** Nothing. Follow Phases 0–6 as written.
+
+**Phase mapping:**
+
+| Phase | What you do |
+|-------|------------|
+| 0 | Inventory your custom files (router, fallback, model picker, BYOK settings) |
+| 1 | Install packages, create project |
+| 2 | Wire resolve alongside your custom router via feature flag |
+| 3 | Move your fallback chain config into dashboard routes |
+| 4 | Move your model allowlists into dashboard policies |
+| 5 | Replace your custom model picker with ModelSelector |
+| 6 | Shift traffic, verify, remove custom code |
+
+**Key risk:** Custom routing code is often spread across many files with implicit dependencies. Phase 0 (inventory) is especially important — don't skip it.
+
+---
+
+## Variant B: "I'm using LiteLLM"
+
+LiteLLM is a proxy server that normalises provider APIs. You call LiteLLM's endpoint and it forwards to the configured provider. Common setup: Docker container running `litellm --model gpt-4o`, with a `litellm_config.yaml` defining models, fallbacks, and provider keys.
+
+**What Restormel replaces:**
+- LiteLLM's routing and fallback logic → Restormel routes and steps
+- LiteLLM's model config (`litellm_config.yaml`) → Restormel dashboard (routes, policies, model catalog)
+- LiteLLM's proxy endpoint → your app calls providers directly using the resolve result
+
+**What Restormel does NOT replace:**
+- LiteLLM's request/response normalisation (if you depend on its unified schema). If you need this, keep LiteLLM as a normalisation layer and have Restormel decide _which_ model LiteLLM should use.
+
+**Phase mapping:**
+
+| Phase | LiteLLM-specific notes |
+|-------|----------------------|
+| 0 | Inventory: your `litellm_config.yaml`, the Docker/process setup, and every place your app calls `http://localhost:4000/chat/completions` (or equivalent). Classify the LiteLLM proxy as "REMOVE" (if you want to call providers directly) or "WRAP" (if you want to keep LiteLLM as a normalisation layer with Restormel doing routing). |
+| 1 | Install Restormel packages. No change to LiteLLM yet. |
+| 2 | Wire Restormel resolve. If keeping LiteLLM: resolve returns the model, and you pass that model to LiteLLM. If removing LiteLLM: resolve returns the provider, and you call the provider SDK directly. |
+| 3 | Translate `litellm_config.yaml` fallback settings into dashboard routes. Each LiteLLM fallback model becomes a step in a Restormel route. |
+| 4 | Translate any LiteLLM `allowed_models` or budget settings into Restormel policies. |
+| 5 | If LiteLLM had no UI, this is net-new. If it did, replace with Restormel ModelSelector. |
+| 6 | Shift traffic. When 100% is on Restormel: stop the LiteLLM container, remove `litellm_config.yaml`, remove Docker/process config. |
+
+### Build-agent prompt: migrate-from-litellm
+
+**Context docs** (adapt paths for your project): this page (Variant B); [Phase 0 — Inventory](/keys/docs/walkthrough/phase-0-inventory) (inventory framework); [Phase 3 — Routes](/keys/docs/walkthrough/phase-3-routes) (route/step model); [Phase 4 — Policies](/keys/docs/walkthrough/phase-4-policies) (policy types).
+
+**Prompt:**
+
+> You are working in [your app repo] which currently uses LiteLLM for AI provider routing.
+>
+> **Goal:** Inventory the LiteLLM integration and produce a migration plan to Restormel Keys.
+>
+> **Steps:**
+>
+> 1. Locate the LiteLLM config: `litellm_config.yaml`, `litellm_settings`, Docker Compose file, or equivalent.
+> 2. Extract: list of models, fallback order, any `allowed_models` or `blocked_models`, budget/rate-limit settings, provider API keys (note which env vars — do not copy the values).
+> 3. Locate every place in the codebase that calls the LiteLLM proxy endpoint (e.g. `http://localhost:4000/chat/completions` or `LITELLM_BASE_URL`).
+> 4. For each LiteLLM feature, map to the Restormel equivalent:
+>    - LiteLLM model list → Restormel route steps
+>    - LiteLLM fallback models → Restormel route with `fallback_chain` mode
+>    - LiteLLM `allowed_models` → Restormel `model_allowlist` policy
+>    - LiteLLM budget → Restormel `budget_cap` policy
+>    - LiteLLM provider keys → Restormel provider credentials (or keep in your own env)
+> 5. Decide: remove LiteLLM entirely (call providers directly) or keep LiteLLM as normalisation layer (Restormel decides the model, LiteLLM handles the request format).
+> 6. Write the migration plan to `docs/restormel-integration/01-litellm-migration.md`.
+>
+> **DO NOT:**
+> - Remove LiteLLM or its config yet. This is a plan only.
+> - Copy real API keys into the migration doc.
+> - Assume LiteLLM features that aren't actually configured (check the config file).
+
+**Gate:** A migration plan document exists mapping every LiteLLM feature to its Restormel equivalent, with a decision on whether to keep LiteLLM as a normalisation layer or remove it entirely.
+
+---
+
+## Variant C: "I'm using Portkey"
+
+Portkey is a gateway with routing, fallbacks, caching, and observability. You call Portkey's endpoint with a config header that specifies routing strategy.
+
+**What Restormel replaces:**
+- Portkey's routing configs → Restormel routes and steps
+- Portkey's fallback strategies → Restormel `fallback_chain` route mode
+- Portkey's model restrictions → Restormel policies
+
+**What Restormel does NOT replace:**
+- Portkey's request caching (if you use it, you'll need a separate caching layer)
+- Portkey's observability/tracing (Restormel is not an observability tool — use your existing tracing)
+
+**Phase mapping:**
+
+| Phase | Portkey-specific notes |
+|-------|----------------------|
+| 0 | Inventory: Portkey configs (JSON headers or API configs), the Portkey API key, every place your app calls `https://api.portkey.ai/v1/...` or uses the Portkey SDK. |
+| 1 | Install Restormel packages alongside Portkey. |
+| 2 | Wire Restormel resolve. Your app calls resolve first, then makes the provider call directly (instead of through Portkey). Feature flag gates which path runs. |
+| 3 | Translate Portkey routing configs (provider order, fallback strategy) into dashboard routes with steps. |
+| 4 | Translate any Portkey model restrictions or budget controls into Restormel policies. |
+| 5 | Embed Restormel UI. Portkey has no embeddable BYOK UI — this is net-new. |
+| 6 | Shift traffic. When 100% is on Restormel: remove Portkey SDK, delete Portkey API key, cancel Portkey subscription if applicable. |
+
+**Key difference from LiteLLM:** Portkey configs are typically JSON objects passed as headers or configured via their dashboard/SDK. You'll need to extract the routing logic from those configs manually.
+
+---
+
+## Variant D: "I'm using OpenRouter"
+
+OpenRouter is a unified API that routes requests to multiple providers with a single endpoint. You call `https://openrouter.ai/api/v1/chat/completions` with a model name, and OpenRouter handles provider selection.
+
+**What Restormel replaces:**
+- OpenRouter's implicit provider routing → Restormel explicit routes and steps (you control _exactly_ which provider handles each model)
+- OpenRouter's model selection → Restormel ModelSelector with policy constraints
+
+**What Restormel does NOT replace:**
+- OpenRouter's access to providers you don't have direct accounts with. If you use OpenRouter because it gives you access to models you can't get directly, you may want to keep OpenRouter as a provider _within_ Restormel's routing (i.e. a step in a route that calls OpenRouter).
+
+**Phase mapping:**
+
+| Phase | OpenRouter-specific notes |
+|-------|--------------------------|
+| 0 | Inventory: every place your app calls the OpenRouter API, the OpenRouter API key, any model-specific logic. |
+| 1 | Install Restormel packages. Set up direct provider accounts (OpenAI, Anthropic, Google) for the models you use — or keep OpenRouter as a "provider" in your route. |
+| 2 | Wire resolve. The resolve result tells you which provider to call. If keeping OpenRouter as a provider, add it as a custom provider in your config. |
+| 3 | Create routes. If you previously relied on OpenRouter to pick the cheapest provider for a given model, replicate that as explicit route steps (e.g. Step 1: OpenAI for gpt-4o, Step 2: OpenRouter for gpt-4o as fallback). |
+| 4 | Add policies. OpenRouter has no policy concept — this is net-new governance. |
+| 5 | Embed ModelSelector. OpenRouter has no embeddable UI — this is net-new. |
+| 6 | Shift traffic. When 100% is on Restormel: remove OpenRouter SDK/API calls, revoke OpenRouter API key if no longer needed. |
+
+**Key difference:** OpenRouter abstracts away provider choice entirely. Moving to Restormel means you're taking explicit control of which provider handles each request. This is more work but gives you full visibility and policy control.
+
+---
+
+## Comparison: what each source gives you that Restormel doesn't
+
+| Feature | LiteLLM | Portkey | OpenRouter | Restormel approach |
+|---------|---------|---------|------------|-------------------|
+| Request/response normalisation | Yes (proxy) | Yes (proxy) | Yes (proxy) | No — call providers directly with their SDKs. Use Restormel for routing decisions only. |
+| Request caching | Plugin | Yes | No | Not in scope — use a caching layer (Redis, CDN, etc.) |
+| Observability / tracing | Plugin | Yes | Basic | Not in scope — use your existing tracing (PostHog, Datadog, etc.) |
+| Access to providers you don't have accounts with | No | No | Yes | No — you need direct provider accounts (or keep OpenRouter as a step in a route) |
+| Embeddable BYOK UI | No | No | No | **Yes** — KeyManager, ModelSelector |
+| Policy enforcement (allowlists, budgets) | Partial | Partial | No | **Yes** — first-class policies in the dashboard |
+| Library-first (no proxy/container) | SDK only | No | No | **Yes** — headless core, no infrastructure required |
+
+---
+
+## The safe strangler approach in detail
+
+Regardless of your source system, the strangler approach follows the same sequence:
+
+```mermaid
+graph TD
+    A["Week 1: Install Restormel alongside old system"] --> B["Week 1-2: Wire resolve behind feature flag"]
+    B --> C["Week 2: Configure routes + policies in dashboard"]
+    C --> D["Week 2-3: 5% traffic through Restormel"]
+    D --> E{"Errors?"}
+    E -->|"Yes"| F["Fix, then retry at 5%"]
+    E -->|"No"| G["25% traffic"]
+    G --> H{"Errors?"}
+    H -->|"Yes"| F
+    H -->|"No"| I["50% → 100% traffic"]
+    I --> J["Burn-in: 1 release cycle"]
+    J --> K["Remove old system"]
+
+```
+
+**Timeline:** Most teams complete the migration in 2–3 weeks. The burn-in period before removing the old system is typically one release cycle (1–2 weeks).
+
+**Rollback at any point:** Flip the feature flag to `false` and 100% of traffic returns to the old system instantly. No code change, no deployment — just an env var.
+
+---
+
+## Checkpoint
+
+You now have:
+
+- A clear mapping from your source system (custom, LiteLLM, Portkey, or OpenRouter) to the walkthrough phases.
+- A strangler approach that lets you migrate incrementally with instant rollback.
+- Source-specific notes on what Restormel replaces and what it doesn't.
+- (If LiteLLM) A build-agent prompt for producing a migration plan document.
+
+**Next:** [Verification strategy](/keys/docs/walkthrough/verification-strategy) — ongoing checks for dashboard, CLI, and smoke tests after integration.

--- a/docs/walkthrough/10-verification-strategy.md
+++ b/docs/walkthrough/10-verification-strategy.md
@@ -1,0 +1,238 @@
+# Verification Strategy
+
+> **Canonical** verification approach for Restormel Keys integrations — during rollout and ongoing.
+
+This document defines three layers of verification: **dashboard checks** (visual, no code), **CLI checks** (terminal, scriptable), and **smoke tests** (HTTP, automatable). Use all three during cutover (Phase 6) and the first two on an ongoing basis.
+
+---
+
+## 1. Verification layers
+
+| Layer | When to use | Who runs it | Automatable? |
+|-------|------------|------------|--------------|
+| **Dashboard** | After any config change (route, policy, credential); during cutover monitoring | Human (or browser MCP) | Partially |
+| **CLI** | After install, before deploy, in CI, during cutover | Human or CI | Yes |
+| **Smoke tests** | After deploy, during cutover, as a scheduled health check | CI or cron | Yes |
+
+---
+
+## 2. Dashboard checks
+
+Open the [Dashboard](/keys/dashboard) and verify the following. These checks require no code — just visual confirmation.
+
+### 2.1 Project health
+
+| What to check | Where | Expected |
+|--------------|-------|----------|
+| Project exists | Projects list | Your project is listed |
+| Environment exists | Project → Environments | `production` (and `staging` if used) |
+| Gateway Key exists | Project → API Keys | At least one key with `rk_…` prefix |
+| Provider credentials valid | Project → Provider Credentials | Green "valid" status for each configured provider |
+
+### 2.2 Route health
+
+| What to check | Where | Expected |
+|--------------|-------|----------|
+| Routes exist | Project → Routes | At least one route (e.g. `ingestion`, `interactive`) |
+| Steps in correct order | Route detail | Steps listed in your intended fallback order |
+| Route mode correct | Route detail | `fallback_chain` (or your intended mode) |
+
+### 2.3 Policy health
+
+| What to check | Where | Expected |
+|--------------|-------|----------|
+| Policies exist | Project → Policies | At least one policy (e.g. `model_allowlist`) |
+| Policy scope correct | Policy detail | Scoped to the right project/environment |
+| No conflicting policies | Policies list | No two policies that contradict each other (e.g. an allowlist and denylist that block everything) |
+
+### 2.4 Usage and logs
+
+| What to check | Where | Expected |
+|--------------|-------|----------|
+| Request count non-zero | Project → Usage | After cutover, requests should appear |
+| No error spikes | Project → Usage / Logs | Error rate comparable to or lower than pre-cutover |
+| Correct route distribution | Project → Usage | Traffic hitting the expected routes |
+
+---
+
+## 3. CLI checks
+
+These checks run in a terminal and can be scripted into CI.
+
+### 3.1 `keys doctor`
+
+```bash
+npx @restormel/keys-cli doctor
+```
+
+**Checks:** Framework detection, packages installed, config file validity, and whether local provider keys are present (if you use them).
+
+**Expected:** Exit code 0, all checks green.
+
+**When to run:** After install (Phase 1), before every deploy, in CI on every PR.
+
+### 3.2 `keys validate`
+
+```bash
+npx @restormel/keys-cli validate
+```
+
+**Checks:** Re-validates all stored provider keys (makes lightweight test calls to each provider).
+
+**Expected:** Exit code 0 if all keys are valid. Exit code 1 if any key is invalid or expired.
+
+**When to run:** Before deploy, in CI on a schedule (e.g. daily), after rotating any provider keys.
+
+> **Tip**
+> `keys validate` with exit code 1 is designed for CI gates. Add it to your deploy pipeline so deploys fail if a provider key has been revoked or expired.
+
+```yaml
+# .github/workflows/deploy.yml
+- name: Validate Restormel keys
+  run: npx @restormel/keys-cli validate
+```
+
+### 3.3 `keys estimate` (optional)
+
+```bash
+npx @restormel/keys-cli estimate gpt-4o --input 1000 --output 500
+```
+
+**Checks:** Returns the estimated cost for a given model and token count.
+
+**When to run:** Before enabling a new model in a route, to understand cost implications.
+
+---
+
+## 4. Smoke tests
+
+These are HTTP-based tests that verify the resolve endpoint and policy evaluation. They are automatable and should run after every deploy and on a schedule.
+
+### 4.1 Resolve smoke test
+
+```bash
+RESULT=$(curl -sf -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "ingestion" }')
+
+PROVIDER=$(echo $RESULT | jq -r '.data.providerType')
+if [ -z "$PROVIDER" ] || [ "$PROVIDER" = "null" ]; then
+  echo "FAIL: resolve returned no provider"
+  exit 1
+fi
+echo "PASS: resolve returned provider=$PROVIDER"
+```
+
+**Expected:** HTTP 200, non-null `provider` in response.
+
+### 4.2 Fallback smoke test
+
+Create a dedicated **test route** in the dashboard with a deliberately failing first step:
+
+| Step | Provider | Credential | Purpose |
+|------|----------|-----------|---------|
+| 1 | `test-invalid` | None | Deliberately fails |
+| 2 | OpenAI | Valid | Should be returned after fallback |
+
+```bash
+RESULT=$(curl -sf -X POST \
+  "https://restormel.dev/keys/dashboard/api/projects/${RESTORMEL_PROJECT_ID}/resolve" \
+  -H "Authorization: Bearer ${RESTORMEL_GATEWAY_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "environmentId": "production", "routeId": "test-fallback" }')
+
+PROVIDER=$(echo $RESULT | jq -r '.data.providerType')
+if [ "$PROVIDER" != "openai" ]; then
+  echo "FAIL: fallback did not resolve to openai (got $PROVIDER)"
+  exit 1
+fi
+echo "PASS: fallback resolved to openai"
+```
+
+### 4.3 Policy smoke test
+
+```bash
+# Allowed model
+EVAL=$(curl -sf -X POST \
+  "https://restormel.dev/keys/dashboard/api/policies/evaluate" \
+  -H "Authorization: Bearer ${RESTORMEL_MANAGEMENT_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "projectId": "'${RESTORMEL_PROJECT_ID}'", "environmentId": "production", "modelId": "gpt-4o", "providerType": "openai" }')
+echo "Allowed model: $(echo $EVAL | jq '.data.allowed')"
+
+# Blocked model
+EVAL_BLOCKED=$(curl -sf -X POST \
+  "https://restormel.dev/keys/dashboard/api/policies/evaluate" \
+  -H "Authorization: Bearer ${RESTORMEL_MANAGEMENT_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{ "projectId": "'${RESTORMEL_PROJECT_ID}'", "environmentId": "production", "modelId": "gpt-3.5-turbo", "providerType": "openai" }')
+echo "Blocked model: $(echo $EVAL_BLOCKED | jq '.data.allowed')"
+```
+
+### 4.4 Combined smoke test script
+
+The script from Phase 6 (Step 6.4) combines all checks:
+
+```bash
+pnpm run smoke:restormel
+```
+
+---
+
+## 5. Ongoing monitoring recommendations
+
+| What | How | Frequency |
+|------|-----|-----------|
+| Resolve latency | Log time per `restormelResolve()` call; alert if p95 > 200ms | Every request |
+| Resolve errors | Count errors from resolve client; alert on spike | Every request |
+| Fallback rate | Count fallback-to-legacy or next-step events; alert if > 5% | Every request |
+| Credential expiry | `keys validate` in CI; alert on exit code 1 | Daily |
+| Policy violations | Dashboard logs; alert if unexpected blocks | Daily |
+| Budget utilisation | Dashboard usage; alert at 80% of cap | Daily |
+| Config drift | `keys doctor` in CI; alert on warnings | Every deploy |
+
+### Build-agent prompt: add-ci-verification
+
+**Context docs** (adapt paths for your project): this page (CLI checks, smoke tests, CI integration); [Phase 6 — Go live](/keys/docs/walkthrough/phase-6-golive) (smoke test script).
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Add Restormel Keys verification steps to your CI pipeline.
+>
+> **Steps:**
+>
+> 1. Open your CI workflow file (e.g. `.github/workflows/ci.yml`).
+> 2. Add a step after build: `npx @restormel/keys-cli doctor`. Fail the build on non-zero exit.
+> 3. Add a step: `npx @restormel/keys-cli validate`. Fail the build on non-zero exit. Requires `RESTORMEL_GATEWAY_KEY` as a CI secret.
+> 4. Add the CI secret: GitHub → Settings → Secrets → Actions → `RESTORMEL_GATEWAY_KEY` (use a staging key, not production).
+> 5. Optionally add a post-deploy step: `pnpm run smoke:restormel`. Gate behind an env check if the staging endpoint isn't available during CI.
+> 6. Verify: push a PR, confirm doctor and validate pass in CI.
+>
+> **DO NOT:**
+> - Use the production Gateway Key in CI. Use a dedicated staging key.
+> - Commit secrets to the workflow file. Use GitHub Actions secrets.
+> - Make the smoke test block deploys if it tests against an unavailable endpoint.
+
+**Gate:** CI runs `keys doctor` and `keys validate` on every PR. Both pass. Gateway Key is a GitHub Actions secret.
+
+---
+
+## 6. Verification schedule summary
+
+| Event | Checks to run |
+|-------|--------------|
+| **Phase 1 complete** | `keys doctor` |
+| **Phase 2 complete** | `keys doctor`, resolve curl test |
+| **Phase 3 complete** | Resolve with route ID, fallback test |
+| **Phase 4 complete** | Policy evaluate (allowed + blocked) |
+| **Phase 5 complete** | Visual: ModelSelector renders, callbacks fire |
+| **Phase 6 cutover** | Full smoke test, dashboard usage, error rate |
+| **Ongoing** | `keys doctor` + `keys validate` in CI; smoke test on schedule; dashboard monitoring |
+
+---
+
+See the [Walkthrough](/keys/docs/walkthrough) index for the full phase listing and related docs.

--- a/docs/walkthrough/11-prompt-index.md
+++ b/docs/walkthrough/11-prompt-index.md
@@ -1,0 +1,421 @@
+# Prompt Index
+
+> **Status:** Proposed. Single collection of every build-agent prompt from the walkthrough, numbered for reference, with full context doc links. Use this as the execution companion alongside the walkthrough pages.
+
+Execute prompts in order. Each prompt's **Context docs** list must be read (or provided to your coding agent) before running the prompt. Gates must pass before proceeding to the next prompt.
+
+---
+
+## Prompt inventory
+
+| # | Prompt name | Source page | Phase |
+|---|------------|-------------|-------|
+| P01 | `inventory-current-routing` | [Phase 0](./02-phase-0-inventory.md) §0.3 | 0 |
+| P02 | `add-feature-flag` | [Phase 0](./02-phase-0-inventory.md) §0.5 | 0 |
+| P03 | `install-and-configure` | [Phase 1](./03-phase-1-install.md) §1.7 | 1 |
+| P04 | `create-resolve-client` | [Phase 2](./04-phase-2-resolve.md) §2.5 | 2 |
+| P05 | `create-local-resolve` | [Phase 2](./04-phase-2-resolve.md) §2.6 | 2 |
+| P06 | `wire-route-ids` | [Phase 3](./05-phase-3-routes.md) §3.5 | 3 |
+| P07 | `add-policies-and-error-handling` | [Phase 4](./06-phase-4-policies.md) §4.6 | 4 |
+| P08 | `embed-ui-components` | [Phase 5](./07-phase-5-ui.md) §5.7 | 5 |
+| P09 | `create-smoke-test` | [Phase 6](./08-phase-6-golive.md) §6.4 | 6 |
+| P10 | `remove-legacy-routing` | [Phase 6](./08-phase-6-golive.md) §6.5 | 6 |
+| P11 | `migrate-from-litellm` | [Migration paths](./09-migration-paths.md) Variant B | Migration |
+| P12 | `add-ci-verification` | [Verification strategy](./10-verification-strategy.md) §5 | Ongoing |
+
+---
+
+## P01 — `inventory-current-routing`
+
+**Phase:** 0  **Source:** [02-phase-0-inventory.md](./02-phase-0-inventory.md) §0.3
+
+**Context docs:**
+- `docs/walkthrough/02-phase-0-inventory.md` — the audit framework
+- `docs/reference/sophia-dogfooding-plan.md` — §0 "Remove SOPHIA custom routing" (reference pattern)
+- `docs/reference/sophia-integration.md` — §2 "Create keys-adapter" (adapter pattern)
+- `docs/02-architecture.md` — §1 "Framework compatibility" and §2 "Package structure"
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Audit the codebase to produce a routing inventory for Restormel Keys integration.
+>
+> **Steps:**
+> 1. Search for all AI provider SDK imports (`openai`, `@anthropic-ai/sdk`, `@google/generative-ai`, or equivalent). List every file that creates a provider client or calls a completion/chat endpoint.
+> 2. For each file found, trace backwards: what decides which provider and model to use? List the routing/selection logic files.
+> 3. Search for model selection UI (dropdowns, selectors, settings pages). List those components.
+> 4. Search for BYOK / key management code. List those files.
+> 5. For each item, classify as REMOVE (Restormel replaces it), KEEP (app-specific), or WRAP (insert resolve before existing call).
+> 6. Document the current provider call pattern for at least one primary entry point.
+> 7. Write results to `docs/restormel-integration/00-routing-inventory.md`.
+>
+> **DO NOT:** Delete or modify any existing code. Commit real API keys. Guess — trace actual code paths.
+
+**Gate:** Routing inventory document exists with classified files and at least one documented call pattern.
+
+---
+
+## P02 — `add-feature-flag`
+
+**Phase:** 0  **Source:** [02-phase-0-inventory.md](./02-phase-0-inventory.md) §0.5
+
+**Context docs:**
+- `docs/walkthrough/02-phase-0-inventory.md` — §0.5 feature flag pattern
+- `docs/walkthrough/04-phase-2-resolve.md` — Phase 2 (where the flag gets used)
+- `docs/walkthrough/08-phase-6-golive.md` — Phase 6 (where the flag gets flipped)
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Add a feature flag `USE_RESTORMEL_KEYS` to gate the integration.
+>
+> **Steps:**
+> 1. Create a feature flags module exporting `USE_RESTORMEL_KEYS` from `process.env`, defaulting to `false`.
+> 2. In each provider resolution function (from inventory), add a conditional: if flag true, call placeholder `restormelResolve()` (throws "not yet implemented"); otherwise call existing logic.
+> 3. Add `USE_RESTORMEL_KEYS=false` to `.env.example`.
+> 4. Verify app starts with no behaviour change.
+>
+> **DO NOT:** Set flag to `true`. Modify existing routing logic. Implement `restormelResolve`. Commit secrets.
+
+**Gate:** App starts unchanged. Flag in `.env.example`. Conditional branch in place.
+
+---
+
+## P03 — `install-and-configure`
+
+**Phase:** 1  **Source:** [03-phase-1-install.md](./03-phase-1-install.md) §1.7
+
+**Context docs:**
+- `docs/walkthrough/03-phase-1-install.md` — this phase
+- `docs/02-architecture.md` — §1 framework compatibility, §2 package structure
+- `docs/walkthrough/02-phase-0-inventory.md` — routing inventory (confirms framework)
+- `packages/core/src/keys.ts` — `createKeys` function
+- `packages/cli/README.md` — CLI commands
+- `docs/ux-contracts.md` — canonical Dashboard URLs
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Install Restormel Keys packages, scaffold config, prepare env vars.
+>
+> **Steps:**
+> 1. Read routing inventory to confirm framework.
+> 2. Install correct packages (Next.js: core + react + elements; SvelteKit: core + svelte; server-only: core).
+> 3. Run `npx @restormel/keys-cli init`.
+> 4. Add to `.env.example`: `RESTORMEL_GATEWAY_KEY=`, `RESTORMEL_PROJECT_ID=`, `RESTORMEL_ENVIRONMENT_ID=`, `USE_RESTORMEL_KEYS=false`.
+> 5. Run `npx @restormel/keys-cli doctor` — confirm exit 0.
+> 6. Commit config, `.env.example`, `package.json`, lockfile.
+>
+> **DO NOT:** Commit real keys. Add values to `.env.example`. Modify application code. Install wrong packages.
+
+**Gate:** `keys doctor` exits 0. Config committed. `.env.example` lists four vars. No secrets committed.
+
+---
+
+## P04 — `create-resolve-client`
+
+**Phase:** 2  **Source:** [04-phase-2-resolve.md](./04-phase-2-resolve.md) §2.5
+
+**Context docs:**
+- `docs/walkthrough/04-phase-2-resolve.md` — resolve client, feature flag wiring, error handling
+- `docs/walkthrough/02-phase-0-inventory.md` — identifies legacy resolve function
+- `packages/core/src/server/resolve.ts` — resolve middleware (response shape)
+- `packages/core/src/router.ts` — `ResolveResult`, `NO_KEY_AVAILABLE`
+- `docs/reference/sophia-dogfooding-plan.md` — §1 and build-agent prompt
+- `docs/reference/sophia-integration.md` — §5 resolve handler
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Create typed resolve client, wire into feature flag, add error handling with legacy fallback.
+>
+> **Steps:**
+> 1. Read routing inventory to identify legacy resolve function.
+> 2. Create `src/lib/server/restormel.ts` with `ResolveRequest`/`ResolveResponse` interfaces and `restormelResolve()`.
+> 3. Create/update `src/lib/server/resolve-provider.ts`: flag true → resolve in try/catch with legacy fallback; flag false → legacy.
+> 4. Add `RESTORMEL_BASE_URL=https://restormel.dev/keys/dashboard` to `.env.example` (optional override; defaults to this URL).
+> 5. Create `scripts/test-resolve.ts`.
+> 6. Verify: flag off → unchanged; flag on → Restormel resolve returns `{ data: { providerType, modelId } }`; invalid key → legacy fallback.
+>
+> **DO NOT:** Default flag to true. Log Gateway Key. Modify legacy logic. Remove code. Commit secrets.
+
+**Gate:** Test script prints valid response. Flag off → unchanged. Flag on → Restormel. Invalid key → fallback. No secrets.
+
+---
+
+## P05 — `create-local-resolve`
+
+**Phase:** 2 (optional)  **Source:** [04-phase-2-resolve.md](./04-phase-2-resolve.md) §2.6
+
+**Context docs:**
+- `docs/walkthrough/04-phase-2-resolve.md` — §2.6 local resolve
+- `packages/core/src/keys.ts` — `createKeys`, `KeysInstance`
+- `packages/core/src/router.ts` — `createRouter`, `ResolveResult`
+- `packages/core/src/server/resolve.ts` — `createResolveMiddleware`
+- `docs/reference/sophia-integration.md` — §2 keys-adapter
+- `docs/02-architecture.md` — §2 package structure
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Create local Keys instance for in-process resolve (no HTTP).
+>
+> **Steps:**
+> 1. Create `src/lib/server/restormel-local.ts`.
+> 2. Import `createKeys` and providers from `@restormel/keys`.
+> 3. Configure with `routing.defaultProvider`, `routing.rules`, `getPlatformKey` from env vars.
+> 4. Export `keys` instance.
+> 5. Add local resolve as path option in resolve-provider.
+> 6. Verify: `keys.resolve('openai', 'gpt-4o')` returns correct result.
+>
+> **DO NOT:** Remove HTTP client. Hardcode keys. Import UI in server code. Commit secrets.
+
+**Gate:** `keys.resolve()` valid. Both paths available. Flag defaults off.
+
+---
+
+## P06 — `wire-route-ids`
+
+**Phase:** 3  **Source:** [05-phase-3-routes.md](./05-phase-3-routes.md) §3.5
+
+**Context docs:**
+- `docs/walkthrough/05-phase-3-routes.md` — route/step model, wiring pattern
+- `docs/walkthrough/04-phase-2-resolve.md` — resolve client and flag
+- `docs/reference/sophia-dogfooding-plan.md` — §1 and §2
+- `apps/dashboard/src/routes/keys/dashboard/api/projects/[id]/resolve/+server.ts` — resolve endpoint
+- `packages/core/src/router.ts` — fallback chain logic
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Update resolve wrapper to accept `routeId`, update all call sites.
+>
+> **Steps:**
+> 1. Update `resolveProvider` to accept `{ routeId?, model? }`.
+> 2. Pass `routeId` to `restormelResolve`.
+> 3. Read inventory, identify call sites, update each with appropriate `routeId`.
+> 4. Create additional dashboard routes if needed.
+> 5. Verify: flag on → each call site resolves through intended route.
+>
+> **DO NOT:** Change legacy path. Reference non-existent routes. Remove error handling. Commit secrets.
+
+**Gate:** Call sites pass `routeId`. Correct routes resolve. Legacy unchanged. Fallback works.
+
+---
+
+## P07 — `add-policies-and-error-handling`
+
+**Phase:** 4  **Source:** [06-phase-4-policies.md](./06-phase-4-policies.md) §4.6
+
+**Context docs:**
+- `docs/walkthrough/06-phase-4-policies.md` — policy types, evaluate endpoint
+- `docs/walkthrough/04-phase-2-resolve.md` — resolve error handling
+- `docs/reference/sophia-dogfooding-plan.md` — §2 policies
+- `apps/dashboard/src/routes/keys/dashboard/api/policies/evaluate/+server.ts` — evaluate endpoint
+- `packages/core/src/entitlements.ts` — entitlements engine
+- `docs/01-product-strategy.md` — §5 product modes
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Distinguish policy errors from network/auth errors in resolve handling.
+>
+> **Steps:**
+> 1. In catch block, parse for budget/cap, `no_key_available`, deprecated/blocked.
+> 2. Log each distinctly.
+> 3. Optionally add budget alert mechanism.
+> 4. Legacy fallback still runs.
+> 5. Verify: low budget cap → caught and logged, legacy runs.
+>
+> **DO NOT:** Change legacy fallback. Remove Phase 2 handling. Expose raw errors. Commit secrets.
+
+**Gate:** Policy errors logged distinctly. Legacy runs on failure. No raw errors to users.
+
+---
+
+## P08 — `embed-ui-components`
+
+**Phase:** 5  **Source:** [07-phase-5-ui.md](./07-phase-5-ui.md) §5.7
+
+**Context docs:**
+- `docs/walkthrough/07-phase-5-ui.md` — embedding patterns
+- `docs/02-architecture.md` — framework compatibility, package structure
+- `packages/react/README.md` — React wrapper API
+- `packages/svelte/src/ModelSelector.test.ts` — ModelSelector props
+- `packages/elements/README.md` — Web Component API
+- `docs/ux-contracts.md` — §3 state conventions
+- `docs/reference/sophia-dogfooding-plan.md` — §3 UI embedding
+- `docs/reference/sophia-integration.md` — §2 KeyStorage pattern
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Embed ModelSelector (and optionally KeyManager) in settings page.
+>
+> **Steps:**
+> 1. Read inventory for existing UI to replace.
+> 2. Embed ModelSelector per framework (React: KeysProvider + client component; SvelteKit: direct; Web Components: element + JS props).
+> 3. Wire `onSelect` to save preference.
+> 4. (If BYOK) Embed KeyManager with callbacks to key API.
+> 5. Add `--rk-*` CSS overrides.
+> 6. Handle loading/error/empty states.
+> 7. Verify: renders, callbacks fire, theme applies, keyboard nav works.
+>
+> **DO NOT:** Import UI in server code. Log raw keys. Skip states. Hardcode models. Commit secrets.
+
+**Gate:** ModelSelector renders + callbacks. KeyManager (if used) works. Theme applies. States handled. Keyboard works.
+
+---
+
+## P09 — `create-smoke-test`
+
+**Phase:** 6  **Source:** [08-phase-6-golive.md](./08-phase-6-golive.md) §6.4
+
+**Context docs:**
+- `docs/walkthrough/08-phase-6-golive.md` — smoke test, post-cutover
+- `docs/walkthrough/04-phase-2-resolve.md` — resolve endpoint
+- `docs/walkthrough/06-phase-4-policies.md` — evaluate endpoint
+- `docs/runbooks/zuplo-setup.md` — §7 validation pattern
+- `packages/cli/README.md` — doctor/validate
+- `docs/testing-strategy.md` — verification scope
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Create post-cutover smoke test script.
+>
+> **Steps:**
+> 1. Create `scripts/smoke-test-restormel.sh` (bash, executable).
+> 2. Resolve call, evaluate for allowed + blocked, `keys doctor`, `keys validate`. Exit 0/1.
+> 3. Read from env vars — no hardcoded secrets.
+> 4. Add `"smoke:restormel"` to package.json scripts.
+> 5. Verify in staging.
+>
+> **DO NOT:** Hardcode secrets. Make destructive calls. Skip doctor/validate.
+
+**Gate:** `pnpm run smoke:restormel` exits 0 in staging. No hardcoded secrets.
+
+---
+
+## P10 — `remove-legacy-routing`
+
+**Phase:** 6 (post-burn-in)  **Source:** [08-phase-6-golive.md](./08-phase-6-golive.md) §6.5
+
+**Context docs:**
+- `docs/walkthrough/08-phase-6-golive.md` — §6.5 removal scope
+- `docs/walkthrough/02-phase-0-inventory.md` — REMOVE items
+- `docs/walkthrough/04-phase-2-resolve.md` — flag and legacy fallback
+- `docs/reference/sophia-dogfooding-plan.md` — §0 removal pattern
+- `docs/reference/sophia-integration.md` — what to keep
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Remove legacy routing after Restormel handles all traffic.
+>
+> **Steps:**
+> 1. Delete every REMOVE item from inventory.
+> 2. Remove flag, remove `legacyResolve`, always use `restormelResolve` (keep try/catch with safe default).
+> 3. Remove flag module if single-purpose.
+> 4. Remove flag vars from `.env.example`.
+> 5. Remove replaced UI components.
+> 6. Remove unused env vars.
+> 7. Run tests. Run smoke test.
+>
+> **DO NOT:** Remove KEEP items. Remove error handling. Remove env vars used elsewhere. Remove smoke test.
+
+**Gate:** REMOVE items deleted. Flag gone. Always Restormel. Tests pass. Smoke passes.
+
+---
+
+## P11 — `migrate-from-litellm`
+
+**Phase:** Migration  **Source:** [09-migration-paths.md](./09-migration-paths.md) Variant B
+
+**Context docs:**
+- `docs/walkthrough/09-migration-paths.md` — Variant B
+- `docs/walkthrough/02-phase-0-inventory.md` — inventory framework
+- `docs/walkthrough/05-phase-3-routes.md` — route/step model
+- `docs/walkthrough/06-phase-4-policies.md` — policy types
+- `docs/02-architecture.md` — package structure
+- `docs/01-product-strategy.md` — §8 competitive positioning
+
+**Prompt:**
+
+> You are working in [your app repo] which uses LiteLLM.
+>
+> **Goal:** Inventory LiteLLM and produce migration plan.
+>
+> **Steps:**
+> 1. Locate LiteLLM config.
+> 2. Extract: models, fallback, allowed/blocked, budget, key env var names.
+> 3. Locate all proxy calls.
+> 4. Map to Restormel: models → steps, fallback → fallback_chain, allowed → allowlist policy, budget → budget_cap.
+> 5. Decide: remove LiteLLM or keep as normalisation layer.
+> 6. Write to `docs/restormel-integration/01-litellm-migration.md`.
+>
+> **DO NOT:** Remove LiteLLM yet. Copy real keys. Assume unconfigured features.
+
+**Gate:** Migration plan maps features. Includes keep/remove decision.
+
+---
+
+## P12 — `add-ci-verification`
+
+**Phase:** Ongoing  **Source:** [10-verification-strategy.md](./10-verification-strategy.md) §5
+
+**Context docs:**
+- `docs/walkthrough/10-verification-strategy.md` — CLI checks, smoke tests, CI
+- `docs/walkthrough/08-phase-6-golive.md` — smoke test script
+- `packages/cli/README.md` — doctor/validate
+- `docs/testing-strategy.md` — testing strategy
+- `.github/workflows/ci.yml` — CI workflow
+
+**Prompt:**
+
+> You are working in [your app repo].
+>
+> **Goal:** Add Restormel verification to CI.
+>
+> **Steps:**
+> 1. Add CI step: `keys doctor` (fail on non-zero).
+> 2. Add CI step: `keys validate` (needs `RESTORMEL_GATEWAY_KEY` secret).
+> 3. Add GitHub Actions secret (staging key).
+> 4. Optionally add post-deploy smoke test.
+> 5. Verify: push PR, both pass.
+>
+> **DO NOT:** Use production key. Commit secrets. Block on unavailable endpoint.
+
+**Gate:** CI runs doctor + validate. Both pass. Key is Actions secret.
+
+---
+
+## Execution order
+
+**Fresh integration (no prior gateway):**
+
+```
+P01 → P02 → P03 → P04 → P06 → P07 → P08 → P09 → [cutover] → P10 → P12
+```
+
+P05 (local resolve) is optional, alongside or instead of P04.
+
+**LiteLLM migration:**
+
+```
+P11 → P01 → P02 → P03 → P04 → P06 → P07 → P08 → P09 → [cutover] → P10 → P12
+```
+
+---
+
+*See [Master index](./00-index.md) for the full walkthrough file listing and reading order.*

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "check-secrets": "bash scripts/check-secrets.sh",
     "check-deps": "bash scripts/check-dependency-policy.sh",
     "check-token-drift": "bash scripts/check-token-drift.sh",
-    "bootstrap-paddle": "tsx scripts/bootstrap-paddle.ts"
+    "bootstrap-paddle": "tsx scripts/bootstrap-paddle.ts",
+    "quality": "bash scripts/quality.sh",
+    "check:dashboard": "pnpm --filter dashboard run check && pnpm --filter dashboard run build",
+    "smoke:dashboard": "bash scripts/smoke-dashboard-docs.sh"
   },
   "devDependencies": {
     "tsx": "^4.19.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@neondatabase/serverless':
         specifier: ^1.0.2
         version: 1.0.2
+      '@restormel/keys':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@restormel/keys-react':
+        specifier: workspace:*
+        version: link:../../packages/react
       '@sveltejs/adapter-vercel':
         specifier: ^6.3.3
         version: 6.3.3(@sveltejs/kit@2.55.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2)))(rollup@4.59.0)

--- a/scripts/quality.sh
+++ b/scripts/quality.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run coding-quality checks locally: dashboard typecheck + build, docs, secrets, hygiene.
+# Exit 0 only if all pass. Run from repo root: pnpm run quality
+set -e
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "[quality] Dashboard check (svelte-check)..."
+pnpm --filter dashboard run check
+
+echo "[quality] Dashboard build..."
+pnpm --filter dashboard run build
+
+echo "[quality] Dashboard unit tests..."
+pnpm --filter dashboard run test
+
+echo "[quality] Review docs..."
+bash scripts/review-docs.sh
+
+echo "[quality] Secret check..."
+bash scripts/check-secrets.sh
+
+echo "[quality] Repo hygiene..."
+bash scripts/check-repo-hygiene.sh
+
+# Optional: smoke-test docs routes (catches runtime 500s e.g. undefined refs in templates)
+if [ -n "${RUN_SMOKE:-}" ]; then
+  echo "[quality] Smoke-testing docs routes..."
+  bash scripts/smoke-dashboard-docs.sh
+fi
+
+echo "[quality] All checks passed."

--- a/scripts/smoke-dashboard-docs.sh
+++ b/scripts/smoke-dashboard-docs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Smoke-test key docs routes after dashboard build: start preview, GET URLs, expect 200.
+# Run from repo root after: pnpm --filter dashboard run build
+# Exit 0 if all URLs return 2xx; exit 1 on 5xx or unreachable.
+set -e
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+PREVIEW_PORT="${PREVIEW_PORT:-4173}"
+BASE="http://127.0.0.1:${PREVIEW_PORT}"
+
+# Build if needed so preview has something to serve
+if [ ! -d "apps/dashboard/.svelte-kit/output" ]; then
+  echo "[smoke] Building dashboard..."
+  pnpm --filter dashboard run build
+fi
+
+echo "[smoke] Starting dashboard preview on port ${PREVIEW_PORT}..."
+pnpm --filter dashboard run preview &
+PREV_PID=$!
+trap 'kill $PREV_PID 2>/dev/null || true' EXIT
+
+# Wait for server to respond (retry a few times)
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -s -o /dev/null -w "%{http_code}" "${BASE}/keys/docs" 2>/dev/null | grep -q '^[23]'; then
+    break
+  fi
+  if [ "$i" -eq 10 ]; then
+    echo "[smoke] Preview did not become ready in time."
+    exit 1
+  fi
+  sleep 1
+done
+
+FAILED=0
+for path in "/keys/docs" "/keys/docs/walkthrough/phase-0-inventory" \
+  "/keys/docs/walkthrough/phase-2-resolve" "/keys/docs/walkthrough/phase-3-routes"; do
+  CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE}${path}" 2>/dev/null || echo "000")
+  if [ "$CODE" = "000" ] || [ "${CODE#5}" != "$CODE" ]; then
+    echo "[smoke] FAIL ${path} → ${CODE}"
+    FAILED=1
+  else
+    echo "[smoke] OK   ${path} → ${CODE}"
+  fi
+done
+
+[ "$FAILED" -eq 0 ] || exit 1
+echo "[smoke] All docs routes returned 2xx."


### PR DESCRIPTION
## Summary
- Standardize docs code snippets with a shared CodeBlock component (copy + language variants/tabs).
- Make callouts (tip/note/pitfall/security) visually distinct so they don’t blend into page content.
- Fix multiple Svelte parse/runtime issues that were causing docs/dashboard 500s.
- Add local quality scripts (typecheck/build/tests/docs/secrets/hygiene + optional docs smoke) and run dashboard check/build/test in CI.

## Test plan
- [x] `pnpm --filter dashboard run check`
- [x] `pnpm run quality`

## Notes
- Callout styling is centralized in `apps/dashboard/src/routes/keys/docs/+layout.svelte` to keep a single source of truth.

Made with [Cursor](https://cursor.com)