### PR TITLE
Fix sandbox 500 + nav recoverability

### DIFF
--- a/apps/dashboard/src/routes/keys/dashboard/sandbox/+page.ts
+++ b/apps/dashboard/src/routes/keys/dashboard/sandbox/+page.ts
@@ -1,0 +1,4 @@
+// The sandbox imports SDK + embeddable UI packages that are designed for the browser.
+// Disable SSR so the dashboard shell renders, then hydrate on the client.
+export const ssr = false;
+


### PR DESCRIPTION
## Summary
- Disables SSR for `/keys/dashboard/sandbox` so the page doesn’t 500 during server rendering (sandbox imports browser-oriented SDK/UI modules).
- Fixes sidebar recoverability:
  - Docs: when the docs sidebar is collapsed, an always-available **Expand nav** control is shown so users can restore the nav.
  - Dashboard: moves the nav toggle into the topbar (always reachable) and removes the redundant logo from the sidebar (logo already in the site header).

## Test plan
- `pnpm -w --filter dashboard build`
- `pnpm -w --filter dashboard preview` then open:
  - `/keys/dashboard/sandbox`
  - `/keys/docs` (collapse and re-expand nav)
  - `/keys/dashboard` (collapse and re-expand nav)