### PR TITLE
fix(zuplo-gateway): clear remaining Dependabot alerts on gateway lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Single record of meaningful repo changes.
 
 ## Repo (2026-03-26)
 
-**Dependency security (pnpm):** Root `pnpm.overrides` extended so transitive deps meet patched versions for open Dependabot/npm advisories (`fastify`, `kysely`, `picomatch`, `yaml`). `pnpm-lock.yaml` refreshed; `pnpm audit` reports no known vulnerabilities.
+**Dependency security (pnpm):** Root `pnpm.overrides` extended so transitive deps meet patched versions for open Dependabot/npm advisories (`fastify`, `kysely`, `picomatch`, `yaml`). `pnpm-lock.yaml` refreshed; `pnpm audit` reports no known vulnerabilities. **`zuplo-gateway/`** is a separate install (not in the root workspace): its `package.json` overrides now pin `fastify` ≥5.8.3 and `picomatch` ≥2.3.2, with `zuplo-gateway/pnpm-lock.yaml` refreshed via `pnpm install --ignore-workspace` so GitHub Dependabot alerts on that manifest clear on the next scan.
 
 **Dogfood → GitHub:** [docs/github-dogfood-feedback.md](docs/github-dogfood-feedback.md) — **default for trusted consumer repos** is label relay (`restormel-feedback` + PAT secret). Self-contained copy for SOPHIA and other consumers: [docs/reference/restormel-dogfood-relay-consumer-pack.md](docs/reference/restormel-dogfood-relay-consumer-pack.md) (includes agent prompt). Issue form and reference workflow remain: [docs/reference/github-dogfood-relay-consumer-workflow.yml](docs/reference/github-dogfood-relay-consumer-workflow.yml). **SOPHIA plan** updated: [docs/reference/sophia-dogfooding-plan.md](docs/reference/sophia-dogfooding-plan.md).
 

--- a/zuplo-gateway/README.md
+++ b/zuplo-gateway/README.md
@@ -24,7 +24,7 @@ This directory is the **Zuplo API gateway** project for the **Restormel Keys con
 
 **Option B — CLI (deploy from this folder)**
 
-1. Install dependencies (includes Zuplo CLI): from this directory run `pnpm install` (or `npm install`). Node 20+ required.
+1. Install dependencies (includes Zuplo CLI): from this directory run `pnpm install --ignore-workspace` if this folder lives inside the Restormel Keys monorepo (otherwise plain `pnpm install`), or use `npm install`. Node 20+ required. The `--ignore-workspace` flag ensures this package’s own `pnpm-lock.yaml` is updated instead of only the repo root lockfile.
 2. Get an API key: Zuplo Portal → Settings → API Keys. Set `ZUPLO_API_KEY` in your environment (do not commit).
 3. Create project (if not already created):  
    `pnpm exec zuplo project create --name restormel-keys-gateway`  
@@ -55,7 +55,7 @@ Then run:
 
 ```bash
 cd zuplo-gateway
-pnpm install
+pnpm install --ignore-workspace
 # If this folder is not yet linked to your Zuplo project, run: pnpm exec zuplo link
 ./scripts/setup-from-cli.sh
 ```

--- a/zuplo-gateway/package.json
+++ b/zuplo-gateway/package.json
@@ -14,7 +14,8 @@
   },
   "pnpm": {
     "overrides": {
-      "fastify": ">=5.7.3",
+      "fastify": ">=5.8.3",
+      "picomatch": ">=2.3.2",
       "undici": ">=6.24.0",
       "minimatch": ">=10.2.3",
       "js-yaml": ">=4.1.1",

--- a/zuplo-gateway/pnpm-lock.yaml
+++ b/zuplo-gateway/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fastify: '>=5.7.3'
+  fastify: '>=5.8.3'
+  picomatch: '>=2.3.2'
   undici: '>=6.24.0'
   minimatch: '>=10.2.3'
   js-yaml: '>=4.1.1'
@@ -1383,10 +1384,10 @@ packages:
   fastify-sse-v2@3.1.2:
     resolution: {integrity: sha512-eEgxBv04wWtrIupDKw65DtdI8Q4XJA3IGstefkSU8qgDlUlexc7+cixxowxlSGj1pz/HC3QsKGLhna+fb7snOQ==}
     peerDependencies:
-      fastify: '>=5.7.3'
+      fastify: '>=5.8.3'
 
-  fastify@5.8.2:
-    resolution: {integrity: sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==}
+  fastify@5.8.4:
+    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1817,9 +1818,9 @@ packages:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pino-abstract-transport@0.4.0:
     resolution: {integrity: sha512-Znl3f1ntZnDG+NpCyJyJDS+lkrlRSbgQBkV3eqNAvet/QHql6rhKLc4DuYRlwfc3fvV611O9NXPm5pbT9AJ50g==}
@@ -3197,9 +3198,9 @@ snapshots:
       esbuild: 0.25.2
       execa: 6.1.0
       fast-glob: 3.3.3
-      fastify: 5.8.2
+      fastify: 5.8.4
       fastify-plugin: 4.5.1
-      fastify-sse-v2: 3.1.2(fastify@5.8.2)
+      fastify-sse-v2: 3.1.2(fastify@5.8.4)
       ignore: 5.3.1
       javascript-stringify: 2.1.0
       jose: 5.9.2
@@ -3255,7 +3256,7 @@ snapshots:
       '@sinclair/typebox': 0.34.33
       '@zuplo/errors': 6.59.52
       chokidar: 4.0.3
-      fastify: 5.8.2
+      fastify: 5.8.4
       pino: 10.0.0
       pino-http: 11.0.0
       pino-http-print: 3.1.0
@@ -3352,7 +3353,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 4.0.4
 
   argparse@2.0.1: {}
 
@@ -3706,14 +3707,14 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify-sse-v2@3.1.2(fastify@5.8.2):
+  fastify-sse-v2@3.1.2(fastify@5.8.4):
     dependencies:
-      fastify: 5.8.2
+      fastify: 5.8.4
       fastify-plugin: 4.5.1
       it-pushable: 1.4.2
       it-to-stream: 1.0.0
 
-  fastify@5.8.2:
+  fastify@5.8.4:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -3991,7 +3992,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 4.0.4
 
   mime-db@1.52.0: {}
 
@@ -4123,7 +4124,7 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
-  picomatch@2.3.1: {}
+  picomatch@4.0.4: {}
 
   pino-abstract-transport@0.4.0:
     dependencies:
@@ -4328,7 +4329,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 4.0.4
 
   readdirp@4.1.2: {}
 


### PR DESCRIPTION
## Context
GitHub Dependabot still reported **3 open alerts** (1 high, 2 moderate), all tied to `zuplo-gateway/pnpm-lock.yaml`: transitive `picomatch@2.3.1` and `fastify@5.8.2`. The root monorepo lockfile was already addressed in #46; the gateway uses a **separate** lockfile and was not updated by root `pnpm install`.

## Changes
- `zuplo-gateway/package.json`: `fastify` override `>=5.8.3`, add `picomatch` `>=2.3.2`
- Refresh `zuplo-gateway/pnpm-lock.yaml` via `pnpm install --no-frozen-lockfile --ignore-workspace` (required so pnpm does not only resolve the repo root workspace)
- README: document `--ignore-workspace` for monorepo installs
- CHANGELOG: note gateway lockfile maintenance

## Verification
- `cd zuplo-gateway && pnpm audit --ignore-workspace` — no known vulnerabilities

After merge, Dependabot should mark alerts **#26, #33, #34** fixed on the next scan.

Made with [Cursor](https://cursor.com)