### PR TITLE
fix(ci): dogfood agent cron picks relayed [Dogfood] + task issues

### DIFF
--- a/.github/workflows/dogfood-agent-open-pr.yml
+++ b/.github/workflows/dogfood-agent-open-pr.yml
@@ -1,7 +1,9 @@
 # LLM-assisted dogfood automation: opens a **draft** PR from a `[Dogfood]` issue.
 # Requires repo secrets: ANTHROPIC_API_KEY and/or OPENAI_API_KEY (see docs).
-# Opt-in scheduled pickup: labels `dogfood-agent-auto` + `task` on an open `[Dogfood]` issue
-# without `dogfood-agent-pr`. Manual runs: Actions → this workflow → workflow_dispatch.
+# Scheduled pickup: open `[Dogfood]` issues with label `task` (relay default), not yet handled by
+# the agent (`dogfood-agent-pr` / `dogfood-agent-noop` / `dogfood-agent-skip`). Optional label
+# `dogfood-agent-auto` is no longer required — SOPHIA relay only applies `task`. Manual runs:
+# Actions → this workflow → workflow_dispatch.
 name: Dogfood agent — draft PR
 
 on:
@@ -45,18 +47,26 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'dogfood-agent-auto,task',
+              labels: 'task',
               sort: 'created',
               direction: 'asc',
-              per_page: 30,
+              per_page: 50,
             });
             const has = (issue, name) => issue.labels.some((l) => l.name === name);
             const candidate = data.find(
-              (i) => /\[dogfood\]/i.test(i.title) && !has(i, 'dogfood-agent-pr'),
+              (i) =>
+                /\[dogfood\]/i.test(i.title) &&
+                !has(i, 'dogfood-agent-pr') &&
+                !has(i, 'dogfood-agent-noop') &&
+                !has(i, 'dogfood-agent-skip'),
             );
             const n = candidate ? String(candidate.number) : '';
             core.setOutput('issue_number', n);
-            if (!n) core.info('No queued issue (labels dogfood-agent-auto + task, title [Dogfood], not dogfood-agent-pr).');
+            if (!n) {
+              core.info(
+                'No queued issue (need: label task, title [Dogfood], and not dogfood-agent-pr / dogfood-agent-noop / dogfood-agent-skip).',
+              );
+            }
 
       - name: Resolve issue number
         id: resolve
@@ -178,6 +188,37 @@ jobs:
               body: [
                 '🤖 Dogfood agent finished with **no file edits** (model returned an empty plan or deferred to a human).',
                 '',
+                'Label **`dogfood-agent-noop`** was added so the scheduler does not retry every few minutes. Remove that label if you want another agent pass.',
+                '',
                 `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               ].join('\n'),
+            });
+
+      - name: Label issue after noop (stop reschedule loop)
+        if: >-
+          success() &&
+          !(github.event_name == 'schedule' && steps.resolve.outputs.issue_number == '') &&
+          steps.run_agent.outputs.noop == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const n = parseInt('${{ steps.resolve.outputs.issue_number }}', 10);
+            try {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: 'dogfood-agent-noop',
+                color: 'C5DEF5',
+                description: 'Dogfood CI agent returned no file edits; remove to allow another scheduled run',
+              });
+            } catch (e) {
+              if (e.status !== 422) core.warning(String(e));
+            }
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: n,
+              labels: ['dogfood-agent-noop'],
             });

--- a/.github/workflows/dogfood-issue-hint.yml
+++ b/.github/workflows/dogfood-issue-hint.yml
@@ -28,6 +28,7 @@ jobs:
               '1. **Security:** Do not copy secrets from the source body into code or PRs. See `docs/security-baseline.md`.',
               '2. **Runbook:** Follow **[docs/runbooks/restormel-dogfood-issue-implementation.md](https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/blob/main/docs/runbooks/restormel-dogfood-issue-implementation.md)** (triage → implement → PR → optional reply on source issue).',
               '3. **Cursor:** Paste the agent prompt from that runbook (section *Cursor agent prompt*), replacing `N` with **' + n + '**.',
+              '4. **CI draft PR (optional):** If **`ANTHROPIC_API_KEY`** or **`OPENAI_API_KEY`** is set in repo Actions secrets, **Dogfood agent — draft PR** will pick **`[Dogfood]`** + **`task`** issues on its schedule (oldest first). To skip automatic agent runs for this issue, add label **`dogfood-agent-skip`**. If the agent returns no edits, it adds **`dogfood-agent-noop`** (remove to retry).',
               '',
               'Relay policy: `docs/github-dogfood-feedback.md`.',
             ].join('\n');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ Single record of meaningful repo changes.
 
 ## Repo (2026-03-26)
 
+**Dogfood agent schedule:** `.github/workflows/dogfood-agent-open-pr.yml` scheduled pickup now matches **SOPHIA relay** issues: label **`task`** + **`[Dogfood]`** title (no longer requires **`dogfood-agent-auto`**). Excludes **`dogfood-agent-pr`**, **`dogfood-agent-noop`**, **`dogfood-agent-skip`**. After a **noop** run, the workflow adds **`dogfood-agent-noop`** so cron does not retry in a loop. Docs: runbook §6, `docs/github-dogfood-feedback.md`, `docs/reference/restormel-dogfood-sophia-handover.md`, hint comment in `dogfood-issue-hint.yml`.
+
 **Dependency security (pnpm):** Root `pnpm.overrides` extended so transitive deps meet patched versions for open Dependabot/npm advisories (`fastify`, `kysely`, `picomatch`, `yaml`). `pnpm-lock.yaml` refreshed; `pnpm audit` reports no known vulnerabilities. **`zuplo-gateway/`** is a separate install (not in the root workspace): its `package.json` overrides now pin `fastify` ≥5.8.3 and `picomatch` ≥2.3.2, with `zuplo-gateway/pnpm-lock.yaml` refreshed via `pnpm install --ignore-workspace` so GitHub Dependabot alerts on that manifest clear on the next scan.
 
 **Dogfood → GitHub:** [docs/github-dogfood-feedback.md](docs/github-dogfood-feedback.md) — **default for trusted consumer repos** is label relay (`restormel-feedback` + PAT secret). Self-contained copy for SOPHIA and other consumers: [docs/reference/restormel-dogfood-relay-consumer-pack.md](docs/reference/restormel-dogfood-relay-consumer-pack.md) (includes agent prompt). Issue form and reference workflow remain: [docs/reference/github-dogfood-relay-consumer-workflow.yml](docs/reference/github-dogfood-relay-consumer-workflow.yml). **SOPHIA plan** updated: [docs/reference/sophia-dogfooding-plan.md](docs/reference/sophia-dogfooding-plan.md).
 
-**Dogfood agent schedule:** `.github/workflows/dogfood-agent-open-pr.yml` cron set to **every 5 minutes** for short-term testing of `dogfood-agent-auto` pickup — restore `0 */6 * * *` (or similar) when done.
+**Dogfood agent cron:** `.github/workflows/dogfood-agent-open-pr.yml` may still be **every 5 minutes** for short-term testing — restore `0 */6 * * *` (or similar) when done.
 
-**Dogfood CI draft PR (optional):** [docs/runbooks/restormel-dogfood-issue-implementation.md](docs/runbooks/restormel-dogfood-issue-implementation.md) §6 — `scripts/dogfood-agent-open-pr.mjs` and `.github/workflows/dogfood-agent-open-pr.yml` (LLM → allowlisted paths → **draft** PR). Secrets: `ANTHROPIC_API_KEY` and/or `OPENAI_API_KEY`. Scheduled pickup: labels `dogfood-agent-auto` + `task`.
+**Dogfood CI draft PR (optional):** [docs/runbooks/restormel-dogfood-issue-implementation.md](docs/runbooks/restormel-dogfood-issue-implementation.md) §6 — `scripts/dogfood-agent-open-pr.mjs` and `.github/workflows/dogfood-agent-open-pr.yml` (LLM → allowlisted paths → **draft** PR). Secrets: `ANTHROPIC_API_KEY` and/or `OPENAI_API_KEY`.
 
 **Dogfood upstream → consumer notify (optional):** `.github/workflows/dogfood-upstream-notify-consumer.yml` — on **`keys-v*`** tag (or manual dispatch), opens a tracking issue on the consumer repo when **`DOGFOOD_NOTIFY_CONSUMER`** (variable) and **`DOGFOOD_NOTIFY_CONSUMER_TOKEN`** (PAT) are set. Spec: [docs/github-dogfood-feedback.md](docs/github-dogfood-feedback.md) § *Upstream → consumer notify*. **SOPHIA handover / test plan:** [docs/reference/restormel-dogfood-sophia-handover.md](docs/reference/restormel-dogfood-sophia-handover.md).
 

--- a/docs/github-dogfood-feedback.md
+++ b/docs/github-dogfood-feedback.md
@@ -144,7 +144,7 @@ Use the same content rules as the issue form.
 
 - **Implementing the work:** [docs/runbooks/restormel-dogfood-issue-implementation.md](runbooks/restormel-dogfood-issue-implementation.md) — checklist, security, Cursor prompt, PR linkage.
 - **Automation:** New issues whose title contains **`[Dogfood]`** get a short GitHub comment from `.github/workflows/dogfood-issue-hint.yml` linking to that runbook.
-- **CI draft PR (optional):** `.github/workflows/dogfood-agent-open-pr.yml` runs `scripts/dogfood-agent-open-pr.mjs` with **`ANTHROPIC_API_KEY`** and/or **`OPENAI_API_KEY`** in **GitHub Actions secrets** (never commit). Manual **workflow_dispatch** or scheduled pickup with labels **`dogfood-agent-auto`** + **`task`** — see runbook § *CI agent (draft PR)*.
+- **CI draft PR (optional):** `.github/workflows/dogfood-agent-open-pr.yml` runs `scripts/dogfood-agent-open-pr.mjs` with **`ANTHROPIC_API_KEY`** and/or **`OPENAI_API_KEY`** in **GitHub Actions secrets** (never commit). Manual **workflow_dispatch** or **scheduled** pickup: open **`[Dogfood]`** issues with label **`task`** (relay default), excluding **`dogfood-agent-pr`** / **`dogfood-agent-noop`** / **`dogfood-agent-skip`** — see runbook § *CI agent (draft PR)*.
 - **Upstream → consumer ping (optional):** After a **`keys-v*`** tag, `.github/workflows/dogfood-upstream-notify-consumer.yml` can open an issue on the consumer repo — variable **`DOGFOOD_NOTIFY_CONSUMER`**, secret **`DOGFOOD_NOTIFY_CONSUMER_TOKEN`**. See [Upstream → consumer notify](#upstream--consumer-notify-keys-v-tag).
 - **Cursor:** Rule `.cursor/rules/07-dogfood-github-issues.mdc` reminds agents to follow the runbook.
 

--- a/docs/reference/restormel-dogfood-sophia-handover.md
+++ b/docs/reference/restormel-dogfood-sophia-handover.md
@@ -79,9 +79,10 @@
 
 ### D) Optional — CI draft PR agent
 
-1. Ensure LLM secret(s) exist on **restormel-keys**.
-2. **Actions** → **Dogfood agent — draft PR** → run with an issue number; start with **dry run** if offered.
-3. Expect a **draft PR** on **restormel-keys** or a noop / failure with logs — still **human** merge.
+1. Ensure LLM secret(s) exist on **restormel-keys** (`ANTHROPIC_API_KEY` and/or `OPENAI_API_KEY`). Without them, the workflow cannot call the model.
+2. **Scheduled pickup:** Relay-created issues already have **`task`** and **`[Dogfood]`** in the title — **Dogfood agent — draft PR** cron selects the **oldest** matching issue (see runbook; **`dogfood-agent-skip`** opts out; **`dogfood-agent-noop`** stops repeat attempts after an empty plan).
+3. **Manual:** **Actions** → **Dogfood agent — draft PR** → enter the restormel-keys issue number; use **dry run** first if offered.
+4. Expect a **draft** PR or a noop comment — still **human** merge.
 
 ---
 

--- a/docs/runbooks/restormel-dogfood-issue-implementation.md
+++ b/docs/runbooks/restormel-dogfood-issue-implementation.md
@@ -93,13 +93,17 @@ Fully automated pickup uses **`.github/workflows/dogfood-agent-open-pr.yml`** pl
 2. Enter the **restormel-keys issue number**; optionally enable **dry run** (LLM only, no push/PR).
 3. Review the **draft** PR and CI; redact or fix anything unsafe before merge.
 
-### Scheduled (opt-in) pickup
+### Scheduled pickup (relay-friendly)
 
-To queue **one** issue per run on a **schedule** (cron is in `.github/workflows/dogfood-agent-open-pr.yml`; may be set to every few minutes for testing — restore a slower cadence for production), concurrency-limited:
+On each cron tick (see `.github/workflows/dogfood-agent-open-pr.yml`; may be every few minutes during testing — restore a slower cadence for production), the workflow picks **at most one** open issue that has:
 
-1. Ensure the relay issue has **`task`** (added by the consumer relay) and title **`[Dogfood]…`**.
-2. Add label **`dogfood-agent-auto`** (create it in the repo if needed). Do **not** add **`dogfood-agent-pr`** until a PR exists.
-3. After a successful run, the workflow adds **`dogfood-agent-pr`**, removes **`dogfood-agent-auto`**, and comments with the draft PR link.
+- Label **`task`** (applied automatically by the consumer relay, e.g. SOPHIA → restormel-keys), and  
+- Title **`[Dogfood]…`**, and  
+- **None** of: **`dogfood-agent-pr`** (PR already opened), **`dogfood-agent-noop`** (agent returned no file edits — remove this label to allow a retry), **`dogfood-agent-skip`** (opt out of automatic agent runs for this issue).
+
+You **do not** need **`dogfood-agent-auto`** anymore for relayed issues; that label was previously required and caused SOPHIA-raised tickets to sit indefinitely unless someone added it manually.
+
+After a successful run, the workflow adds **`dogfood-agent-pr`** and comments with the draft PR link. If the model proposes **no** file changes, the workflow comments and adds **`dogfood-agent-noop`** so the scheduler does not retry in a tight loop.
 
 **Safety:** Redact consumer issue bodies before relaying; the script **redacts common secret shapes** in the text sent to the provider, but that is **not** a guarantee — treat relay bodies as untrusted (see § Before you start).
 


### PR DESCRIPTION
## Problem
SOPHIA relay creates restormel-keys issues with title `[Dogfood] …` and label `task` only. The **Dogfood agent — draft PR** scheduled job only listed issues with **both** `dogfood-agent-auto` **and** `task`, so relayed issues never matched and no draft PR was opened.

## Change
- Schedule: list open issues with label `task`, take the oldest whose title matches `[Dogfood]` and that does **not** have `dogfood-agent-pr`, `dogfood-agent-noop`, or `dogfood-agent-skip`.
- After a **noop** (model returns no file edits), add label `dogfood-agent-noop` and document it so cron does not retry every few minutes.

## Docs
Runbook §6, `docs/github-dogfood-feedback.md`, SOPHIA handover, and the dogfood issue hint comment updated.

## Still required for a PR to appear
Repo Actions secrets `ANTHROPIC_API_KEY` and/or `OPENAI_API_KEY` must be set; otherwise the agent step fails after pick.

## Manual escape hatch
**Actions → Dogfood agent — draft PR → workflow_dispatch** with the issue number still works.

Made with [Cursor](https://cursor.com)