### PR TITLE
fix(ci): dogfood agent — clarify issue # is restormel-keys (404 hint)

### DIFF
--- a/.github/workflows/dogfood-agent-open-pr.yml
+++ b/.github/workflows/dogfood-agent-open-pr.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: restormel-keys issue number
+        description: '[Dogfood] issue # on THIS repo (not SOPHIA/consumer #)'
         required: true
         type: string
       dry_run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Single record of meaningful repo changes.
 
 **Dogfood agent schedule:** `.github/workflows/dogfood-agent-open-pr.yml` scheduled pickup now matches **SOPHIA relay** issues: label **`task`** + **`[Dogfood]`** title (no longer requires **`dogfood-agent-auto`**). Excludes **`dogfood-agent-pr`**, **`dogfood-agent-noop`**, **`dogfood-agent-skip`**. After a **noop** run, the workflow adds **`dogfood-agent-noop`** so cron does not retry in a loop. Docs: runbook §6, `docs/github-dogfood-feedback.md`, `docs/reference/restormel-dogfood-sophia-handover.md`, hint comment in `dogfood-issue-hint.yml`.
 
+**Dogfood agent issue 404:** Manual workflow must use the **restormel-keys** `[Dogfood]` issue number, not the consumer source number; `dogfood-agent-open-pr.mjs` now explains this on **GET …/issues/N** **404**. Runbook + workflow input description updated.
+
 **Dogfood agent branch names:** `dogfood-agent-open-pr.mjs` appends **`GITHUB_RUN_ID`** (or a local timestamp) to agent branch names so retries do not hit **non-fast-forward** when an earlier run already pushed `dogfood/agent-issue-<n>-<sha>`.
 
 **Dogfood agent PR creation:** If **`POST /pulls`** returns **403** (`GitHub Actions is not permitted to create or approve pull requests`), enable **Allow GitHub Actions to create and approve pull requests** under **Actions → General → Workflow permissions** (repo and/or org). Runbook §6 subsection *GitHub must allow Actions to open pull requests*. **`scripts/dogfood-agent-open-pr.mjs`** prefers **`GITHUB_REF_NAME`** for the PR base branch in Actions to avoid `origin/HEAD` symbolic-ref noise.

--- a/docs/runbooks/restormel-dogfood-issue-implementation.md
+++ b/docs/runbooks/restormel-dogfood-issue-implementation.md
@@ -101,8 +101,9 @@ If **`git push`** fails with **non-fast-forward** on `dogfood/agent-issue-…`, 
 ### Manual run
 
 1. **Actions** → **Dogfood agent — draft PR** → **Run workflow**.
-2. Enter the **restormel-keys issue number**; optionally enable **dry run** (LLM only, no push/PR).
-3. Review the **draft** PR and CI; redact or fix anything unsafe before merge.
+2. Enter the **restormel-keys** issue number (the **`[Dogfood] …`** ticket in **this** repo). **Do not** use the consumer repo issue number from SOPHIA — that returns **404**. The relay body usually links to the source issue; the number you need is on **restormel-keys** (`…/restormel-keys/issues/N`).
+3. Optionally enable **dry run** (LLM only, no push/PR).
+4. Review the **draft** PR and CI; redact or fix anything unsafe before merge.
 
 ### Scheduled pickup (relay-friendly)
 

--- a/scripts/dogfood-agent-open-pr.mjs
+++ b/scripts/dogfood-agent-open-pr.mjs
@@ -108,7 +108,23 @@ async function githubJson(method, pathname, body) {
     body: body === undefined ? undefined : JSON.stringify(body),
   });
   const txt = await res.text();
-  if (!res.ok) die(`GitHub API ${method} ${pathname}: ${res.status} ${txt.slice(0, 500)}`);
+  if (!res.ok) {
+    if (res.status === 404 && method === 'GET') {
+      const m = pathname.match(/^\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)$/);
+      if (m) {
+        const [, o, r, n] = m;
+        die(
+          [
+            `GitHub API GET ${pathname}: 404 — no issue #${n} in ${o}/${r} (or token cannot see it).`,
+            '',
+            'Use the **[Dogfood] issue number on restormel-keys**, not the consumer (e.g. SOPHIA) source issue number.',
+            'Open the relayed ticket in this repo and copy N from: github.com/' + o + '/' + r + '/issues/<N>',
+          ].join('\n'),
+        );
+      }
+    }
+    die(`GitHub API ${method} ${pathname}: ${res.status} ${txt.slice(0, 500)}`);
+  }
   return txt ? JSON.parse(txt) : null;
 }
 


### PR DESCRIPTION
## Cause of 404
`GET /issues/74` on **restormel-keys** returns **404** when **#74** is the **consumer** (SOPHIA) issue, not a ticket in this repo.

## Changes
- Script: targeted error text on issue GET 404
- Runbook + workflow input description
- CHANGELOG

Made with [Cursor](https://cursor.com)