### PR TITLE
docs: route-step providerPreference vs project index (dogfood #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Single record of meaningful repo changes.
 
 ## Repo (2026-03-27)
 
+**Dogfood #53:** Route-step `providerPreference` documented as the **authoritative** narrow execution enum (OpenAPI descriptions on `RouteStep`, `RouteStepCreate`, `RouteStepPatch`), with an explicit note that the project model index — including **`registry`** bindings — may list additional provider slugs that are **not** valid on `POST/PATCH .../routes/{routeId}/steps` until Keys widens execution. Guide: [resolve-to-execution-contract.md](docs/guides/resolve-to-execution-contract.md) (*Route step providerPreference*). Developer portal: [zuplo-gateway/docs/pages/dashboard-api/routes-steps.md](zuplo-gateway/docs/pages/dashboard-api/routes-steps.md).
+
 **Dogfood PR consumer (manual):** `.github/workflows/dogfood-pr-comment-consumer-dispatch.yml` — **workflow_dispatch** to post the same consumer issue comment as the automatic PR workflow (e.g. after enabling **`DOGFOOD_NOTIFY_CONSUMER`** post-merge). Uses **`gh api …/pulls/N`** for **`head.repo.full_name`** (`gh pr view` JSON can omit **`nameWithOwner`** on merged PRs). Documented in `docs/github-dogfood-feedback.md`.
 
 **Dogfood PR consumer CI:** When **`DOGFOOD_NOTIFY_CONSUMER`** is unset, `dogfood-pr-comment-consumer.yml` now emits a **warning** (not only a notice) so a green run is not mistaken for a posted SOPHIA comment.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1621,6 +1621,10 @@ components:
         providerPreference:
           type: string
           enum: [openai, anthropic, google, openrouter, vercel, portkey, voyage]
+          description: |
+            **Authoritative** allowed values for persisted route steps (Keys execution / resolve path).
+            Inbound aliases for Google (`vertex`, etc.) normalize to `google` in storage; resolve responses use canonical `vertex` in `providerType`.
+            This enum is **narrower** than `GET/POST .../projects/{projectId}/models`: the project model index may include **`registry`** bindings with arbitrary provider slugs that are valid for catalog merge metadata but **must not** be used here until Keys extends step execution for those providers.
         modelId: { type: string, nullable: true }
         label: { type: string, nullable: true }
         fallbackOn:
@@ -1651,6 +1655,10 @@ components:
         providerPreference:
           type: string
           enum: [openai, anthropic, google, openrouter, vercel, portkey, voyage]
+          description: |
+            **Authoritative** allowed values for persisted route steps (Keys execution / resolve path).
+            Inbound aliases for Google (`vertex`, etc.) normalize to `google` in storage; resolve responses use canonical `vertex` in `providerType`.
+            This enum is **narrower** than `GET/POST .../projects/{projectId}/models`: the project model index may include **`registry`** bindings with arbitrary provider slugs that are valid for catalog merge metadata but **must not** be used here until Keys extends step execution for those providers.
         modelId: { type: string, nullable: true }
         label: { type: string, nullable: true }
         fallbackOn:
@@ -1678,6 +1686,10 @@ components:
         providerPreference:
           type: string
           enum: [openai, anthropic, google, openrouter, vercel, portkey, voyage]
+          description: |
+            **Authoritative** allowed values for persisted route steps (Keys execution / resolve path).
+            Inbound aliases for Google (`vertex`, etc.) normalize to `google` in storage; resolve responses use canonical `vertex` in `providerType`.
+            This enum is **narrower** than `GET/POST .../projects/{projectId}/models`: the project model index may include **`registry`** bindings with arbitrary provider slugs that are valid for catalog merge metadata but **must not** be used here until Keys extends step execution for those providers.
         modelId: { type: string, nullable: true }
         label: { type: string, nullable: true }
         fallbackOn:

--- a/docs/guides/resolve-to-execution-contract.md
+++ b/docs/guides/resolve-to-execution-contract.md
@@ -24,6 +24,12 @@ A successful `POST /api/projects/{projectId}/resolve` guarantees that Restormel 
 
 Policy and cost estimation still use the `google` id internally where `@restormel/keys` `defaultProviders` expects it; hosts should key execution off **`vertex`** for Google/Vertex.
 
+### Route step `providerPreference` (Steps API)
+
+`POST/PATCH .../routes/{routeId}/steps` accept only the **execution** provider slugs Keys can run through resolve today: **`openai`**, **`anthropic`**, **`google`** (inbound aliases such as `vertex` normalize to `google` in storage), **`openrouter`**, **`vercel`**, **`portkey`**, **`voyage`**. This list is **authoritative** and is the same set as the `providerPreference` enum in [openapi.yaml](../api/openapi.yaml) (`RouteStep`, `RouteStepCreate`, `RouteStepPatch`).
+
+It is **intentionally narrower** than the project model index: **`GET/POST .../projects/{projectId}/models`** may list extra providers (for example under **`bindingKind: registry`**) for host catalog merge. Those rows are not valid `providerPreference` values on route steps until Keys widens step validation and execution. Integrators that replace steps from a UI backed by the project index should map or restrict to the step enum so `POST .../steps` does not return **400** (e.g. “must be one of: …”).
+
 ### Project model index (`GET/POST/PUT .../models`, `PATCH/DELETE .../models/{bindingId}`)
 
 Integrators merge **`GET /api/projects/{projectId}/models`** (Dashboard API, **Gateway Key**) with local catalogs. Rows may be **`bindingKind: execution`** (canonical `providerType` per this table, catalog-backed) or **`bindingKind: registry`** (opaque provider/model for host metadata when off-catalog). **Mutations** (`POST` batch add, `PUT` replace, `PATCH` `enabled`, `DELETE`) are Gateway Key–authenticated on the same base path — see in-app **Cloud API** doc, [openapi.yaml](../api/openapi.yaml), [requirements spec](../requirements/project-model-index-gateway-api.md), and [keys-catalog-sync.md](../restormel-integration/keys-catalog-sync.md). Global catalog remains **`GET /api/models`** (unauthenticated).

--- a/zuplo-gateway/docs/pages/dashboard-api/routes-steps.md
+++ b/zuplo-gateway/docs/pages/dashboard-api/routes-steps.md
@@ -25,7 +25,7 @@ Request body shape is `RouteStepCreate` (see product OpenAPI for full schema). T
 
 - `orderIndex` (integer, >= 0, unique within route)
 - `enabled` (boolean)
-- `providerPreference` (enum)
+- `providerPreference` — **authoritative** enum for Keys execution: `openai`, `anthropic`, `google`, `openrouter`, `vercel`, `portkey`, `voyage` (Google inbound aliases such as `vertex` normalize to `google`). This set is **narrower** than the project model index (`GET/POST .../models`): registry bindings may list other provider slugs for merge metadata; those values are **not** valid on route steps until Keys extends the Steps API. See product OpenAPI `RouteStepCreate` / `RouteStepPatch` and [From resolve to execution — route step providerPreference](https://restormel.dev/keys/docs/guides/resolve-to-execution-contract#route-step-providerpreference-steps-api).
 - `modelId` (string)
 - `fallbackOn` (enum)
 


### PR DESCRIPTION
## Summary

Implements option (1) from [issue #53](https://github.com/Allotment-Technology-Ltd/restormel-keys/issues/53): document route-step `providerPreference` as the **authoritative** narrow execution enum, with an explicit note that the project model index (including `registry` bindings) may list additional providers that are not accepted by the Steps API until Keys widens execution.

## Changes

- **OpenAPI** (`docs/api/openapi.yaml`): descriptions on `RouteStep`, `RouteStepCreate`, and `RouteStepPatch` `providerPreference`.
- **Guide** (`docs/guides/resolve-to-execution-contract.md`): new subsection *Route step `providerPreference` (Steps API)*.
- **Developer portal** (`zuplo-gateway/docs/pages/dashboard-api/routes-steps.md`): enumerated values + cross-link to the guide.
- **CHANGELOG**: `Repo (2026-03-27)` entry.

## Out of scope

Extending validation to accept providers such as Mistral (option 2) — requires execution/catalog alignment; tracked for a future change. SOPHIA can keep pre-validation against the documented set.

Fixes #53

Made with [Cursor](https://cursor.com)