### PR TITLE
fix(dogfood #55): route_step_provider_not_allowed + agent JSON parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Single record of meaningful repo changes.
 
 ## Repo (2026-03-27)
 
+**Dogfood #55 / route steps vs project index:** Steps **`POST`/`PATCH`** return **`error`: `route_step_provider_not_allowed`** (with **`allowed`**, **`detail`**) when `providerPreference` is not an execution slug — distinct from **`invalid_step_schema`**. OpenAPI **1.3.3** (`RouteStepProviderNotAllowedError`, step **400** `oneOf`, `providerPreference` descriptions: aggregator pattern). Guide: [resolve-to-execution-contract.md](docs/guides/resolve-to-execution-contract.md). Zuplo: [routes-steps.md](zuplo-gateway/docs/pages/dashboard-api/routes-steps.md).
+
+**Dogfood agent JSON parse:** `scripts/dogfood-agent-open-pr.mjs` — OpenAI **`response_format: json_object`**, stricter system prompt for escaped `content`, and more resilient extraction (invisible chars, trailing commas, `---` prefix, fence fallback) so Actions runs do not fail on malformed multi-file JSON.
+
 **Dogfood #53:** Route-step `providerPreference` documented as the **authoritative** narrow execution enum (OpenAPI descriptions on `RouteStep`, `RouteStepCreate`, `RouteStepPatch`), with an explicit note that the project model index — including **`registry`** bindings — may list additional provider slugs that are **not** valid on `POST/PATCH .../routes/{routeId}/steps` until Keys widens execution. Guide: [resolve-to-execution-contract.md](docs/guides/resolve-to-execution-contract.md) (*Route step providerPreference*). Developer portal: [zuplo-gateway/docs/pages/dashboard-api/routes-steps.md](zuplo-gateway/docs/pages/dashboard-api/routes-steps.md).
 
 **Dogfood PR consumer (manual):** `.github/workflows/dogfood-pr-comment-consumer-dispatch.yml` — **workflow_dispatch** to post the same consumer issue comment as the automatic PR workflow (e.g. after enabling **`DOGFOOD_NOTIFY_CONSUMER`** post-merge). Uses **`gh api …/pulls/N`** for **`head.repo.full_name`** (`gh pr view` JSON can omit **`nameWithOwner`** on merged PRs). Documented in `docs/github-dogfood-feedback.md`.

--- a/apps/dashboard/src/lib/server/route-step-http.ts
+++ b/apps/dashboard/src/lib/server/route-step-http.ts
@@ -1,0 +1,15 @@
+import { json } from "@sveltejs/kit";
+import { ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS } from "$lib/server/canonical-provider";
+
+/** 400 when `providerPreference` is a string but not an allowed route-step execution slug (distinct from typos in other fields). */
+export function jsonRouteStepProviderNotAllowed() {
+  const allowed = [...ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS].sort();
+  return json(
+    {
+      error: "route_step_provider_not_allowed",
+      detail: `providerPreference must be one of: ${allowed.join(", ")} (aliases: vertex → google). Values that appear only on the project model index (for example registry bindings) are not accepted on route steps until Keys adds execution for them. For models reached via an aggregator, use openrouter or portkey with a supported catalog modelId when applicable.`,
+      allowed,
+    },
+    { status: 400 }
+  );
+}

--- a/apps/dashboard/src/routes/keys/dashboard/api/projects/[id]/routes/[routeId]/steps/+server.ts
+++ b/apps/dashboard/src/routes/keys/dashboard/api/projects/[id]/routes/[routeId]/steps/+server.ts
@@ -1,10 +1,8 @@
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { createRouteStep, getModel, getRoute, listRouteSteps } from "$lib/server/db";
-import {
-  normalizeProviderForStorage,
-  ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS,
-} from "$lib/server/canonical-provider";
+import { normalizeProviderForStorage, ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS } from "$lib/server/canonical-provider";
+import { jsonRouteStepProviderNotAllowed } from "$lib/server/route-step-http";
 const FALLBACK_ON = new Set(["error", "rate_limit", "no_key", "policy_block", "any"]);
 
 function projectScope(locals: App.Locals, projectId: string): { projectId: string; userId: string } | null {
@@ -75,9 +73,7 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
   if (typeof providerPreference === "string") {
     const normalized = normalizeProviderForStorage(providerPreference);
     if (!normalized || !ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS.has(normalized)) {
-      return invalid(
-        `providerPreference must be one of: ${[...ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS].sort().join(", ")} (aliases: vertex → google)`
-      );
+      return jsonRouteStepProviderNotAllowed();
     }
     providerPreference = normalized;
   }

--- a/apps/dashboard/src/routes/keys/dashboard/api/projects/[id]/routes/[routeId]/steps/[stepId]/+server.ts
+++ b/apps/dashboard/src/routes/keys/dashboard/api/projects/[id]/routes/[routeId]/steps/[stepId]/+server.ts
@@ -1,10 +1,8 @@
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { deleteRouteStep, getModel, getRoute, listRouteSteps, updateRouteStep } from "$lib/server/db";
-import {
-  normalizeProviderForStorage,
-  ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS,
-} from "$lib/server/canonical-provider";
+import { normalizeProviderForStorage, ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS } from "$lib/server/canonical-provider";
+import { jsonRouteStepProviderNotAllowed } from "$lib/server/route-step-http";
 const FALLBACK_ON = new Set(["error", "rate_limit", "no_key", "policy_block", "any"]);
 
 function projectScope(locals: App.Locals, projectId: string): { projectId: string; userId: string } | null {
@@ -62,9 +60,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
     if (typeof body.providerPreference === "string") {
       const normalized = normalizeProviderForStorage(body.providerPreference);
       if (!normalized || !ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS.has(normalized)) {
-        return invalid(
-          `providerPreference must be one of: ${[...ROUTE_STEP_ALLOWED_STORAGE_PROVIDERS].sort().join(", ")} (aliases: vertex → google)`
-        );
+        return jsonRouteStepProviderNotAllowed();
       }
       body.providerPreference = normalized;
     }

--- a/apps/dashboard/src/routes/keys/dashboard/api/projects/[id]/routes/[routeId]/steps/steps-api.test.ts
+++ b/apps/dashboard/src/routes/keys/dashboard/api/projects/[id]/routes/[routeId]/steps/steps-api.test.ts
@@ -142,7 +142,9 @@ describe("Steps API", () => {
     );
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe("invalid_step_schema");
+    expect(body.error).toBe("route_step_provider_not_allowed");
+    expect(Array.isArray(body.allowed)).toBe(true);
+    expect(body.allowed).toContain("openai");
   });
 
   it("POST duplicate orderIndex returns 409", async () => {

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -5,7 +5,7 @@
 openapi: 3.0.3
 info:
   title: Restormel Keys API
-  version: 1.3.2
+  version: 1.3.3
   description: |
     API for managing projects and API keys. Call through the Zuplo gateway with a consumer API key.
     Authentication is required for all endpoints (API key in Authorization header).
@@ -919,10 +919,15 @@ paths:
                 properties:
                   data: { $ref: "#/components/schemas/RouteStep" }
         "400":
-          description: Validation error
+          description: |
+            Validation error (`invalid_step_schema`, unknown `modelId`, etc.) or **`route_step_provider_not_allowed`**
+            when `providerPreference` is not an allowed execution slug (includes **`allowed`** array for clients).
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/ErrorResponse" }
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/ErrorResponse"
+                  - $ref: "#/components/schemas/RouteStepProviderNotAllowedError"
         "403":
           description: Forbidden
           content:
@@ -974,10 +979,14 @@ paths:
                 properties:
                   data: { $ref: "#/components/schemas/RouteStep" }
         "400":
-          description: Validation error
+          description: |
+            Validation error or **`route_step_provider_not_allowed`** when `providerPreference` is not an allowed execution slug.
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/ErrorResponse" }
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/ErrorResponse"
+                  - $ref: "#/components/schemas/RouteStepProviderNotAllowedError"
         "403":
           description: Forbidden
           content:
@@ -1537,7 +1546,8 @@ components:
           type: string
           description: |
             Machine-readable code. Resolve examples: `unauthorized`, `no_route`, `route_unpublished`, `route_disabled`,
-            `policy_blocked`, `no_key_available`, `resolve_incomplete`, `publish_validation_failed`.
+            `policy_blocked`, `no_key_available`, `resolve_incomplete`, `publish_validation_failed`,
+            `route_step_provider_not_allowed` (route steps: disallowed `providerPreference` slug; body includes `allowed`).
         message: { type: string }
         userMessage: { type: string, description: Operator hint for some 422 errors }
         detail: { type: string }
@@ -1548,6 +1558,20 @@ components:
           items:
             type: object
             additionalProperties: true
+    RouteStepProviderNotAllowedError:
+      type: object
+      description: |
+        Returned when `providerPreference` is a string but not an allowed route-step execution slug (distinct from generic `invalid_step_schema`).
+        Prefer branching on **`error`**; use **`allowed`** for UX or automation. For Mistral-class models routed via an aggregator, use **`openrouter`** or **`portkey`** with a catalog **`modelId`** when supported — not a bare `mistral` slug on the step.
+      required: [error, detail, allowed]
+      properties:
+        error:
+          type: string
+          enum: [route_step_provider_not_allowed]
+        detail: { type: string }
+        allowed:
+          type: array
+          items: { type: string }
     ResolveStepChainEntry:
       type: object
       properties:
@@ -1625,6 +1649,7 @@ components:
             **Authoritative** allowed values for persisted route steps (Keys execution / resolve path).
             Inbound aliases for Google (`vertex`, etc.) normalize to `google` in storage; resolve responses use canonical `vertex` in `providerType`.
             This enum is **narrower** than `GET/POST .../projects/{projectId}/models`: the project model index may include **`registry`** bindings with arbitrary provider slugs that are valid for catalog merge metadata but **must not** be used here until Keys extends step execution for those providers.
+            **Supported pattern for aggregator-only models:** use **`openrouter`** or **`portkey`** as `providerPreference` with the matching Keys catalog **`modelId`** when the model is offered through that path — not a first-party slug such as **mistral** on the step until Keys adds native execution.
         modelId: { type: string, nullable: true }
         label: { type: string, nullable: true }
         fallbackOn:
@@ -1659,6 +1684,7 @@ components:
             **Authoritative** allowed values for persisted route steps (Keys execution / resolve path).
             Inbound aliases for Google (`vertex`, etc.) normalize to `google` in storage; resolve responses use canonical `vertex` in `providerType`.
             This enum is **narrower** than `GET/POST .../projects/{projectId}/models`: the project model index may include **`registry`** bindings with arbitrary provider slugs that are valid for catalog merge metadata but **must not** be used here until Keys extends step execution for those providers.
+            **Supported pattern for aggregator-only models:** use **`openrouter`** or **`portkey`** as `providerPreference` with the matching Keys catalog **`modelId`** when the model is offered through that path — not a first-party slug such as **mistral** on the step until Keys adds native execution.
         modelId: { type: string, nullable: true }
         label: { type: string, nullable: true }
         fallbackOn:
@@ -1690,6 +1716,7 @@ components:
             **Authoritative** allowed values for persisted route steps (Keys execution / resolve path).
             Inbound aliases for Google (`vertex`, etc.) normalize to `google` in storage; resolve responses use canonical `vertex` in `providerType`.
             This enum is **narrower** than `GET/POST .../projects/{projectId}/models`: the project model index may include **`registry`** bindings with arbitrary provider slugs that are valid for catalog merge metadata but **must not** be used here until Keys extends step execution for those providers.
+            **Supported pattern for aggregator-only models:** use **`openrouter`** or **`portkey`** as `providerPreference` with the matching Keys catalog **`modelId`** when the model is offered through that path — not a first-party slug such as **mistral** on the step until Keys adds native execution.
         modelId: { type: string, nullable: true }
         label: { type: string, nullable: true }
         fallbackOn:

--- a/docs/guides/resolve-to-execution-contract.md
+++ b/docs/guides/resolve-to-execution-contract.md
@@ -28,7 +28,11 @@ Policy and cost estimation still use the `google` id internally where `@restorme
 
 `POST/PATCH .../routes/{routeId}/steps` accept only the **execution** provider slugs Keys can run through resolve today: **`openai`**, **`anthropic`**, **`google`** (inbound aliases such as `vertex` normalize to `google` in storage), **`openrouter`**, **`vercel`**, **`portkey`**, **`voyage`**. This list is **authoritative** and is the same set as the `providerPreference` enum in [openapi.yaml](../api/openapi.yaml) (`RouteStep`, `RouteStepCreate`, `RouteStepPatch`).
 
-It is **intentionally narrower** than the project model index: **`GET/POST .../projects/{projectId}/models`** may list extra providers (for example under **`bindingKind: registry`**) for host catalog merge. Those rows are not valid `providerPreference` values on route steps until Keys widens step validation and execution. Integrators that replace steps from a UI backed by the project index should map or restrict to the step enum so `POST .../steps` does not return **400** (e.g. “must be one of: …”).
+It is **intentionally narrower** than the project model index: **`GET/POST .../projects/{projectId}/models`** may list extra providers (for example under **`bindingKind: registry`**) for host catalog merge. Those rows are not valid `providerPreference` values on route steps until Keys widens step validation and execution. Integrators that replace steps from a UI backed by the project index should map or restrict to the step enum.
+
+**HTTP 400** for a disallowed slug uses **`error`: `route_step_provider_not_allowed`** with **`allowed`** (string array) and a **`detail`** hint — distinct from generic **`invalid_step_schema`**. Automations (e.g. SOPHIA save-routing) can branch on **`error`** to show “not routable on steps yet” vs other validation failures.
+
+**Aggregator pattern (Mistral-class, DeepSeek-class, etc.):** if the model is only reachable through OpenRouter, Portkey, or similar, persist the step as **`openrouter`** or **`portkey`** with the **Keys catalog `modelId`** for that path when it exists — not a first-party **`mistral`** / **`deepseek`** slug on the step until Keys adds native execution for that provider.
 
 ### Project model index (`GET/POST/PUT .../models`, `PATCH/DELETE .../models/{bindingId}`)
 

--- a/docs/runbooks/restormel-dogfood-issue-implementation.md
+++ b/docs/runbooks/restormel-dogfood-issue-implementation.md
@@ -77,7 +77,7 @@ Do not commit or log secrets.
 
 ## 6) Optional: CI agent (draft PR)
 
-Fully automated pickup uses **`.github/workflows/dogfood-agent-open-pr.yml`** plus **`scripts/dogfood-agent-open-pr.mjs`**. The workflow calls an LLM (Anthropic or OpenAI), applies edits under a **strict path allowlist** (`docs/`, `apps/`, `packages/`, `scripts/`, `prompts/`, `e2e/` — not `.github/`, not this script), then **pushes a branch** and opens a **draft** PR. **Human review is mandatory** before merge.
+Fully automated pickup uses **`.github/workflows/dogfood-agent-open-pr.yml`** plus **`scripts/dogfood-agent-open-pr.mjs`**. The workflow calls an LLM (Anthropic or OpenAI), applies edits under a **strict path allowlist** (`docs/`, `apps/`, `packages/`, `scripts/`, `prompts/`, `e2e/` — not `.github/`, not this script), then **pushes a branch** and opens a **draft** PR. **Human review is mandatory** before merge. The OpenAI path uses **`response_format: json_object`** so the model reply is valid JSON; the script also tolerates minor formatting issues (invisible chars, trailing commas). Anthropic returns plain text — the same extraction rules apply.
 
 ### One draft PR per dogfood agent pickup (canonical)
 

--- a/scripts/dogfood-agent-open-pr.mjs
+++ b/scripts/dogfood-agent-open-pr.mjs
@@ -12,6 +12,8 @@
  *   DOGFOOD_DRY_RUN=1 — no git push / no PR; prints summary
  *   DOGFOOD_ANTHROPIC_MODEL, DOGFOOD_OPENAI_MODEL
  *   GITHUB_OUTPUT — set by Actions for step outputs
+ *
+ * OpenAI: chat completions use response_format json_object (requires a model that supports it, e.g. gpt-4o-mini).
  */
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -72,27 +74,92 @@ function isAllowedRel(p) {
   return true;
 }
 
-function extractJsonObject(text) {
-  const t = text.trim();
-  const fence = t.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  const inner = fence ? fence[1].trim() : t;
-  const start = inner.indexOf('{');
-  if (start === -1) throw new Error('No JSON object in model output');
+/**
+ * Find the end index of a balanced top-level `{ ... }` while respecting JSON string rules
+ * (so `}` inside "content" values does not truncate the object).
+ */
+function findBalancedJsonObjectEnd(s, start) {
   let depth = 0;
-  let end = -1;
-  for (let i = start; i < inner.length; i += 1) {
-    const c = inner[i];
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < s.length; i += 1) {
+    const c = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (c === '\\') escape = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
     if (c === '{') depth += 1;
     else if (c === '}') {
       depth -= 1;
-      if (depth === 0) {
-        end = i;
-        break;
-      }
+      if (depth === 0) return i;
     }
   }
-  if (end === -1) throw new Error('Unbalanced JSON braces in model output');
-  return JSON.parse(inner.slice(start, end + 1));
+  return -1;
+}
+
+function stripInvisible(s) {
+  return String(s)
+    .replace(/^\uFEFF/, '')
+    .replace(/[\u200B-\u200D\uFEFF]/g, '');
+}
+
+/** Remove trailing commas before `}` or `]` (common invalid JSON from models). */
+function stripTrailingCommas(s) {
+  let out = s;
+  for (let i = 0; i < 12; i += 1) {
+    const next = out.replace(/,(\s*[}\]])/g, '$1');
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
+
+function tryParseJsonObjectSlice(jsonSlice) {
+  const cleaned = stripInvisible(jsonSlice);
+  const attempts = [cleaned, stripTrailingCommas(cleaned)];
+  for (const slice of attempts) {
+    try {
+      return JSON.parse(slice);
+    } catch {
+      /* next */
+    }
+  }
+  return null;
+}
+
+function extractJsonObject(text) {
+  const t = stripInvisible(text.trim());
+  /** @type {string[]} */
+  const candidates = [];
+  const fence = t.match(/```(?:json)?\s*([\s\S]*?)```/im);
+  if (fence) candidates.push(stripInvisible(fence[1].trim()));
+  candidates.push(t);
+
+  for (const raw of candidates) {
+    const inner = raw.replace(/^\s*---\s*/m, '').trim();
+    const start = inner.indexOf('{');
+    if (start === -1) continue;
+    const end = findBalancedJsonObjectEnd(inner, start);
+    if (end === -1) continue;
+    const parsed = tryParseJsonObjectSlice(inner.slice(start, end + 1));
+    if (parsed && typeof parsed === 'object') return parsed;
+  }
+
+  const whole = tryParseJsonObjectSlice(t);
+  if (whole && typeof whole === 'object') return whole;
+
+  throw new Error(
+    'No parseable JSON object in model output (use JSON-escaped strings in "content"; OpenAI path uses response_format json_object)',
+  );
 }
 
 async function githubJson(method, pathname, body) {
@@ -170,6 +237,7 @@ async function callOpenAI(system, user) {
         { role: 'user', content: user },
       ],
       temperature: 0.2,
+      response_format: { type: 'json_object' },
     }),
   });
   const txt = await res.text();
@@ -210,8 +278,10 @@ async function run() {
 
   const system = [
     'You are a coding agent for the restormel-keys monorepo.',
-    'Respond with ONE JSON object only (no markdown fences). Shape:',
+    'Respond with ONE JSON object only. Shape:',
     '{"summary":"one line","files":[{"path":"relative/path","content":"full UTF-8 file contents"}]}',
+    'The entire reply must be valid JSON (OpenAI: json_object mode). No markdown fences unless the fenced block alone is valid JSON.',
+    'If files is non-empty, every "content" value must be JSON-safe: escape double quotes as \\", newlines as \\n, backslashes as \\\\.',
     'Rules:',
     '- Minimal, targeted changes only; no unrelated refactors.',
     '- Respect repository phase/bootstrap constraints (no large new product surfaces unless the issue clearly requires them).',
@@ -219,6 +289,7 @@ async function run() {
     '- Paths must be repo-relative and under these roots only: docs/, apps/, packages/, scripts/, prompts/, e2e/.',
     '- Never touch .github/, never add .env files, never modify scripts/dogfood-agent-open-pr.mjs.',
     '- Provide full file contents for each file (not diffs).',
+    '- Escape JSON properly inside string values: use \\" for double quotes and \\\\ for backslashes in file content.',
     '- If the issue is ambiguous, unsafe, or needs a human decision, return {"summary":"...","files":[]} with explanation in summary.',
   ].join('\n');
 

--- a/zuplo-gateway/docs/pages/dashboard-api/routes-steps.md
+++ b/zuplo-gateway/docs/pages/dashboard-api/routes-steps.md
@@ -45,6 +45,7 @@ Common error codes across steps endpoints:
 - `403`: forbidden (key scope mismatch)
 - `404`: route/step not found
 - `409`: duplicate `orderIndex` within a route
+- `400` with **`error`: `route_step_provider_not_allowed`**: `providerPreference` is not an allowed route-step execution slug. Response includes **`allowed`** (array) and **`detail`**. Registry-only slugs from the project model index are rejected until Keys extends execution; for aggregator-routed models use **`openrouter`** or **`portkey`** with a supported catalog **`modelId`** when applicable (see [From resolve to execution](https://restormel.dev/keys/docs/guides/resolve-to-execution-contract#route-step-providerpreference-steps-api)).
 
 ## Reminder: this is not the gateway surface
 


### PR DESCRIPTION
## Summary

Addresses [issue #55](https://github.com/Allotment-Technology-Ltd/restormel-keys/issues/55) (SOPHIA parity / ingestion route steps) and the **dogfood draft PR workflow** failure you saw.

### Workflow failure (`Failed to parse model JSON`)

The model returned JSON with **invalid string escaping** inside `files[].content` (raw newlines/quotes in markdown). `JSON.parse` then failed; the logged snippet looked valid at a glance because the error separator `---` was confused with content.

**Fixes in `scripts/dogfood-agent-open-pr.mjs`:**
- **OpenAI:** `response_format: { type: "json_object" }` so the top-level reply is valid JSON.
- **System prompt:** explicit requirement to JSON-escape `content` strings.
- **Extraction:** strip invisible chars, strip trailing commas, tolerate `---` prefix, try fenced and unfenced candidates.

### Issue #55 (option 2 from the relay)

Execution enums are **unchanged** (same bar as before). Delivered:
- **`route_step_provider_not_allowed`** on Steps **POST/PATCH** with `allowed` + `detail` — distinct from `invalid_step_schema` for automation (SOPHIA can branch on `error`).
- **OpenAPI 1.3.3:** `RouteStepProviderNotAllowedError`, **400** `oneOf` on create/patch step, `providerPreference` descriptions extended with **openrouter/portkey** aggregator pattern for Mistral-class models.
- **Guide + Zuplo** aligned.

### Tests

`vitest` steps API + stepId API tests updated/passed locally.

Fixes #55

Made with [Cursor](https://cursor.com)