### PR TITLE
Update cron schedule for dogfood-agent-open-pr workflow

### DIFF
--- a/.github/workflows/dogfood-agent-open-pr.yml
+++ b/.github/workflows/dogfood-agent-open-pr.yml
@@ -21,7 +21,7 @@ on:
   schedule:
     # GitHub allows down to every 5 minutes. Default below is aggressive — for **short-term testing** of
     # `dogfood-agent-auto` pickup; restore production cadence with e.g. `0 */6 * * *` (every 6 hours UTC).
-    - cron: '*/5 * * * *'
+    - cron: '*/1 * * * *'
 
 concurrency:
   group: dogfood-agent-open-pr


### PR DESCRIPTION
Change cron schedule from every 5 minutes to every 1 minute for testing.

## What changed
<!-- Brief description of changes -->

## Why
<!-- Reason for the change -->

## Canonical docs updated
<!-- List root or docs/ docs you updated (STATUS, ROADMAP, CHANGELOG, etc.) -->
- [ ] N/A
- [ ] Updated: ___

## Security impact
- [ ] None
- [ ] Low (docs/process only)
- [ ] Higher (describe below)

## Reliability impact
- [ ] None
- [ ] Describe if relevant

## Checks run
- [ ] `scripts/check-repo-hygiene.sh`
- [ ] `scripts/review-docs.sh`
- [ ] `scripts/check-secrets.sh`
- [ ] `scripts/check-dependency-policy.sh`
- [ ] Other (lint/typecheck if applicable): ___

## Scope confirmation
- [ ] This PR respects Phase 00 bootstrap constraints (no product/business logic unless gate lifted)
